### PR TITLE
added continuous retries to make sure deployment is scaled up

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'elasti_retry_on_try_failure'
     paths:
       - 'operator/**'
       - 'resolver/**'

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'elasti_retry_on_try_failure'
     paths:
       - 'operator/**'
       - 'resolver/**'

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -132,9 +132,9 @@ func (h *Handler) handleAnyRequest(w http.ResponseWriter, req *http.Request) (*m
 		}
 		h.hostManager.DisableTrafficForHost(host.IncomingHost)
 		return nil
-	}, func() {
-		h.operatorRPC.SendIncomingRequestInfo(host.Namespace, host.SourceService)
-	}); tryErr != nil {
+		}, func() {
+			h.operatorRPC.SendIncomingRequestInfo(host.Namespace, host.SourceService)
+		}); tryErr != nil {
 		h.logger.Error("throttler try error: ", zap.Error(tryErr))
 		if errors.Is(tryErr, context.DeadlineExceeded) {
 			http.Error(w, "request timeout", http.StatusRequestTimeout)

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -123,7 +123,8 @@ func (h *Handler) handleAnyRequest(w http.ResponseWriter, req *http.Request) (*m
 	// Send request to throttler
 	ctx, cancel := context.WithTimeout(context.Background(), h.timeout)
 	defer cancel()
-	if tryErr := h.throttler.Try(ctx, host, func(count int) error {
+	if tryErr := h.throttler.Try(ctx, host, 
+		func(count int) error {
 		err := h.ProxyRequest(w, req, host.TargetHost, count)
 		if err != nil {
 			h.logger.Error("Error proxying request", zap.Error(err))
@@ -131,6 +132,8 @@ func (h *Handler) handleAnyRequest(w http.ResponseWriter, req *http.Request) (*m
 		}
 		h.hostManager.DisableTrafficForHost(host.IncomingHost)
 		return nil
+	}, func() {
+		h.operatorRPC.SendIncomingRequestInfo(host.Namespace, host.SourceService)
 	}); tryErr != nil {
 		h.logger.Error("throttler try error: ", zap.Error(tryErr))
 		if errors.Is(tryErr, context.DeadlineExceeded) {


### PR DESCRIPTION
With a keda based autoscaling setup.

Two loops run continuously - 
- Prometheus recording every ~ 15s
    - pending pod status
    - traffic
- Keda scaling based on prometheus having the pending pod or traffic data - every 30s

Strategies
- Synchronise keda scaling down and elasti scaling up
    - How?
        - Keda must know that a service is in the middle of scale up by elasti, hence, keda will need to listen to a metric that is emitted from elasti. This would mean, elasti will have to implement a scaler through webhook which keda can listen to
    - Pros
        - We prevent scaling down from happening at all
    - Cons
        - Elasti becomes keda aware which is better avoided
- Add retries to elasti to keep scaling up until the request is fulfilled
    - How?
        - Add retry for elasti to keep scaling up the deployment every 5 seconds
    - Pros
        - Elasti and autoscaler remain decoupled
    - Cons
        - Initial scale down will happen by keda. Although the scale up happens as well by elasti

Remaining problem -
- Even after all this there are failure cases -
    - If prometheus is delays the recording of metrics for some reason, keda can still consider a service for scale down when the first request has been fulfilled by elasti, after which no retries happen