### PR TITLE
Update build image workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -46,7 +46,7 @@ jobs:
     uses: truefoundry/workflows/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      repository: 'elasti-operator'
+      image_artifact_name: 'elasti-operator'
       dockerfile_path: 'operator/Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
       artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
@@ -61,7 +61,7 @@ jobs:
     uses: truefoundry/workflows/.github/workflows/build.yml@main
     with:
       image_tag: ${{ github.sha }}
-      repository: 'elasti-resolver'
+      image_artifact_name: 'elasti-resolver'
       dockerfile_path: 'resolver/Dockerfile'
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
       artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,4 +1,4 @@
-name: Push image to to JFROG Public
+name: Push image to JFROG Public
 
 on:
   push:
@@ -13,17 +13,58 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Build and Push Docker Images
-    strategy:
-      matrix:
-        include:
-          - directory: operator
-            repository: elasti-operator
-          - directory: resolver
-            repository: elasti-resolver
-    uses: truefoundry/workflows/.github/workflows/build-elasti.yml@main
+  get_changed_files:
+    name: Get the changed files
+    runs-on: ubuntu-latest
+    outputs:
+      operator_changed: ${{ steps.check_operator_files.outputs.operator_changed }}
+      resolver_changed: ${{ steps.check_resolver_files.outputs.resolver_changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get the changed files
+        id: get_changed_files
+        run: |
+          files=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | tr '\n' ' ')
+          echo "files=$files" >> $GITHUB_OUTPUT
+
+      - name: Check if operator files changed
+        id: check_operator_files
+        run: echo "operator_changed=${{ contains(steps.get_changed_files.outputs.files, 'operator/') }}" >> $GITHUB_OUTPUT
+
+      - name: Check if resolver files changed
+        id: check_resolver_files
+        run: echo "resolver_changed=${{ contains(steps.get_changed_files.outputs.files, 'resolver/') }}" >> $GITHUB_OUTPUT
+
+  build-operator:
+    name: Build and Push Operator Docker Images
+    if: needs.get_changed_files.outputs.operator_changed == 'true'
+    needs: get_changed_files
+    uses: truefoundry/workflows/.github/workflows/build.yml@main
     with:
-      directory: ${{ matrix.directory}}
-      repository: ${{ matrix.repository}}
-    secrets: inherit
+      image_tag: ${{ github.sha }}
+      repository: 'elasti-operator'
+      dockerfile_path: 'operator/Dockerfile'
+      artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
+      artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
+    secrets:
+      artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
+      artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
+
+  build-resolver:
+    name: Build and Push Resolver Docker Images
+    if: needs.get_changed_files.outputs.resolver_changed == 'true'
+    needs: get_changed_files
+    uses: truefoundry/workflows/.github/workflows/build.yml@main
+    with:
+      image_tag: ${{ github.sha }}
+      repository: 'elasti-resolver'
+      dockerfile_path: 'resolver/Dockerfile'
+      artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
+      artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
+    secrets:
+      artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
+      artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}


### PR DESCRIPTION
Separated the `build-operator` and `build-resolver` jobs to run independently so as to reduce build time and to also ensure that only the workflow for the changed path is run