### PR TITLE
dont scale up replicas if the current replicas are greater

### DIFF
--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -385,7 +385,7 @@ func (h *ScaleHandler) ScaleArgoRollout(ctx context.Context, namespace, targetNa
 	if err != nil {
 		return false, fmt.Errorf("ScaleArgoRollout - Patch: %w", err)
 	}
-	h.logger.Info("Rollout scaled", zap.String("rollout", targetName), zap.Int64("replicas", currentReplicas))
+	h.logger.Info("Rollout scaled", zap.String("rollout", targetName), zap.Int32("replicas", replicas))
 	return true, nil
 }
 


### PR DESCRIPTION
## Description
Right now we are comparing that the number of replicas in deployment/rollout is unequal before attempting to scale up. This is a problem in autoscaled situations where the current number of replicas might in fact be greater than the min replicas set by elasti. This PR fixes that

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for scaling operations when replica information is missing.
  - Prevented unnecessary scaling actions when the current state already matches or exceeds the desired replica count.
  - Enhanced logging to provide clearer feedback on scaling decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->