### PR TITLE
supporting second level cooldown period for prometheus uptime check

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -24,7 +24,7 @@ COPY ./operator/internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/resolver/Dockerfile
+++ b/resolver/Dockerfile
@@ -22,7 +22,7 @@ COPY ./resolver/ .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o resolver cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o resolver cmd/main.go
 
 
 FROM alpine:latest


### PR DESCRIPTION
## Description
We can't assume that the cooldown period is always > 1m

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved Prometheus scaler reliability by updating query formatting and label selectors for uptime checks.
	- Enhanced error messages for Prometheus scaler health checks to display accurate query information.

- **Chores**
	- Optimized Docker image build process for operator and resolver components by refining build commands for efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->