### PR TITLE
Release 0.1.15-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@
 * Add validation for CRD fields for elasti service by @ramantehlan in https://github.com/truefoundry/elasti/pull/122
 * Forward source host to target by @ramantehlan in https://github.com/truefoundry/elasti/pull/123
 
+## 0.1.15-beta (2025-07-28)
+
+### Fixes
+* Forward source host to target by @ramantehlan in https://github.com/truefoundry/elasti/pull/159
+
+### Improvements
+* Supporting second level cooldown period for prometheus uptime check by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/125
+* Add validation for CRD fields for elasti service by @ramantehlan in https://github.com/truefoundry/elasti/pull/138
+
+### Other
+* Add E2E tests via Kuttl by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/123
+* Add Docs for KubeElasti at https://kubeelasti.dev by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/142
+* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /pkg in https://github.com/truefoundry/KubeElasti/pull/156
+* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /operator in https://github.com/truefoundry/KubeElasti/pull/155
+* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /resolver in https://github.com/truefoundry/KubeElasti/pull/151
+* Security Fix: Bump golang.org/x/net from 0.33.0 to 0.38.0 in /pkg in https://github.com/truefoundry/KubeElasti/pull/143
+
+### New Contributors
+* @rethil made their first contribution in https://github.com/truefoundry/KubeElasti/pull/154
+
 ## 0.1.14
 * update workflow to update grype config by @DeeAjayi in https://github.com/truefoundry/KubeElasti/pull/113
 * Add support for namespace scoped elasti controller and fixes for cooldown period tracking by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/115
@@ -24,6 +44,11 @@ All the unreleased changes are listed under `Unreleased` section.
 
 - [Changelog](#changelog)
   - [0.1.15](#0115)
+  - [0.1.15-beta (2025-07-28)](#0115-beta-2025-07-28)
+    - [Fixes](#fixes)
+    - [Improvements](#improvements)
+    - [Other](#other)
+    - [New Contributors](#new-contributors)
   - [0.1.14](#0114)
   - [History](#history)
   - [Unreleased](#unreleased)

--- a/charts/elasti/Chart.yaml
+++ b/charts/elasti/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: elasti
 description: Helm chart for Elasti application
 type: application
-version: 0.1.14
-appVersion: "0.1.14"
+version: 0.1.15-beta
+appVersion: "0.1.15-beta"

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -17,7 +17,7 @@ elastiController:
           - ALL
     image:
       repository: tfy.jfrog.io/tfy-images/elasti-operator
-      tag: 94151d8361cbeb0b6f972dbc662b88dce6b12e35
+      tag: 0.1.15-beta
     imagePullPolicy: IfNotPresent
     resources:
       limits:
@@ -55,7 +55,7 @@ elastiResolver:
       trafficReEnableDuration: "5"
     image:
       repository: tfy.jfrog.io/tfy-images/elasti-resolver
-      tag: 94151d8361cbeb0b6f972dbc662b88dce6b12e35
+      tag: 0.1.15-beta
     imagePullPolicy: IfNotPresent
     resources:
       limits:


### PR DESCRIPTION
# Release 0.1.15-beta

## Fixes
* Forward source host to target by @ramantehlan in https://github.com/truefoundry/elasti/pull/159

## Improvements
* Supporting second level cooldown period for prometheus uptime check by @shubhamrai1993 in https://github.com/truefoundry/KubeElasti/pull/125
* Add validation for CRD fields for elasti service by @ramantehlan in https://github.com/truefoundry/elasti/pull/138

## Other
* Add E2E tests via Kuttl by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/123
* Add Docs for KubeElasti at https://kubeelasti.dev by @ramantehlan in https://github.com/truefoundry/KubeElasti/pull/142
* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /pkg in https://github.com/truefoundry/KubeElasti/pull/156
* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /operator in https://github.com/truefoundry/KubeElasti/pull/155
* Bump golang.org/x/oauth2 from 0.21.0 to 0.27.0 in /resolver in https://github.com/truefoundry/KubeElasti/pull/151
* Security Fix: Bump golang.org/x/net from 0.33.0 to 0.38.0 in /pkg in https://github.com/truefoundry/KubeElasti/pull/143

## New Contributors
* @rethil made their first contribution in https://github.com/truefoundry/KubeElasti/pull/154