### PR TITLE
feat: support HTTP/2 cleartext (H2C) in resolver

### DIFF
--- a/charts/elasti/templates/deployment.yaml
+++ b/charts/elasti/templates/deployment.yaml
@@ -118,6 +118,8 @@ spec:
           value: {{ quote .Values.elastiResolver.proxy.env.maxQueueConcurrency }}
         - name: INITIAL_CAPACITY
           value: {{ quote .Values.elastiResolver.proxy.env.initialCapacity }}
+        - name: ENABLE_H2C
+          value: {{ quote .Values.elastiResolver.proxy.env.enableH2C }}
         {{- if .Values.elastiResolver.proxy.sentry.enabled }}
         - name: SENTRY_DSN
           valueFrom:

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -116,6 +116,7 @@ elastiResolver:
       queueSize: "50000"
       reqTimeout: "600"
       trafficReEnableDuration: "5"
+      enableH2C: false
     image:
       ## @param elastiResolver.proxy.image.registry registry to use for the deployment
       ##


### PR DESCRIPTION
## Description

Add support for HTTP/2 cleartext (H2C) in resolver.
This is necessary to support gRPC services that are not using TLS.

In my case, I am using Istio service mesh to serve both HTTP1 and gRPC (HTTP2) services.
In proxy mode, requests towards gRPC services are sent to the resolver using HTTP/2 cleartext, resulting in a protocol error.

I added support for enabling H2C via an environment variable, which preserves backwards compatibility.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I tested it in my own environment, using both HTTP1 and HTTP2 services.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
- [x] A PR is open to update the helm chart (link)[https://github.com/truefoundry/elasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP/2 cleartext (H2C) support for the resolver proxy. This feature is disabled by default but can be enabled through configuration to support cleartext HTTP/2 connections. Users managing the resolver deployment can now toggle this capability as needed for their infrastructure requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->