### PR TITLE
fix: stage all changes including deletions in helm-main sync workflow

### DIFF
--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -64,6 +64,6 @@ jobs:
           yq -i '.elastiResolver.proxy.image.tag="${{ github.sha }}"' values.yaml
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add values.yaml
+          git add -A
           git commit -m "Update Helm values.yaml on helm-main branch with sha: ${{ github.sha }}" --signoff
           git push --force origin helm-main


### PR DESCRIPTION
The workflow was only staging values.yaml with 'git add values.yaml',
causing file deletions from main branch to not be committed to helm-main.

Changed to 'git add -A' to stage all changes including deletions.

Signed-off-by: Harshit Luthra <25671488+sachincool@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and publish workflow to stage all changes before committing, rather than restricting staged files to specific configurations. This ensures deleted or modified files are included in the deployment process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->