### PR TITLE
implement crd caching for resolver

### DIFF
--- a/charts/elasti/templates/deployment.yaml
+++ b/charts/elasti/templates/deployment.yaml
@@ -129,6 +129,10 @@ spec:
           value: {{ quote .Values.elastiResolver.proxy.env.initialCapacity }}
         - name: ENABLE_H2C
           value: {{ quote .Values.elastiResolver.proxy.env.enableH2C }}
+        {{- with .Values.elastiResolver.proxy.env.crdCachePollIntervalMinutes }}
+        - name: CRD_CACHE_POLL_INTERVAL_MINUTES
+          value: {{ quote . }}
+        {{- end }}
         {{- if .Values.elastiResolver.proxy.sentry.enabled }}
         - name: SENTRY_DSN
           valueFrom:

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -194,6 +194,7 @@ elastiResolver:
       reqTimeout: "600"
       trafficReEnableDuration: "5"
       enableH2C: false
+      crdCachePollIntervalMinutes: "5"
     image:
       ## @param elastiResolver.proxy.image.registry registry to use for the deployment
       ##

--- a/operator/internal/crddirectory/directory.go
+++ b/operator/internal/crddirectory/directory.go
@@ -56,3 +56,15 @@ func GetCRD(serviceName string) (*CRDDetails, bool) {
 	CRDDirectory.Logger.Info("Service found in directory", zap.String("service", serviceName))
 	return value.(*CRDDetails), true
 }
+
+func ListAllCRDs() map[string]*CRDDetails {
+	if CRDDirectory == nil {
+		return nil
+	}
+	result := make(map[string]*CRDDetails)
+	CRDDirectory.Services.Range(func(key, value interface{}) bool {
+		result[key.(string)] = value.(*CRDDetails)
+		return true
+	})
+	return result
+}

--- a/operator/internal/elastiserver/elastiServer.go
+++ b/operator/internal/elastiserver/elastiServer.go
@@ -57,6 +57,7 @@ func (s *Server) Start(port string) error {
 	sentryHandler := sentryhttp.New(sentryhttp.Options{})
 	mux.Handle("/metrics", sentryHandler.Handle(promhttp.Handler()))
 	mux.Handle("/informer/incoming-request", sentryHandler.HandleFunc(s.resolverReqHandler))
+	mux.Handle("/crd-cache", sentryHandler.HandleFunc(s.crdCacheHandler))
 
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%s", strings.TrimPrefix(port, ":")),
@@ -144,6 +145,44 @@ func (s *Server) resolverReqHandler(w http.ResponseWriter, req *http.Request) {
 	s.logger.Info("Request fulfilled successfully",
 		zap.String("service", body.Svc),
 		zap.String("namespace", body.Namespace))
+}
+
+func (s *Server) crdCacheHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	allCRDs := crddirectory.ListAllCRDs()
+	resp := messages.CRDCacheResponse{
+		CRDCache: make(map[string]messages.CRDCacheEntry),
+	}
+	for key, details := range allCRDs {
+		specJSON, err := json.Marshal(details.Spec)
+		if err != nil {
+			s.logger.Error("Failed to marshal CRD spec", zap.String("key", key), zap.Error(err))
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		statusJSON, err := json.Marshal(details.Status)
+		if err != nil {
+			s.logger.Error("Failed to marshal CRD status", zap.String("key", key), zap.Error(err))
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		resp.CRDCache[key] = messages.CRDCacheEntry{
+			CRDName: details.CRDName,
+			Spec:    specJSON,
+			Status:  statusJSON,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.logger.Error("Failed to encode CRD cache response", zap.Error(err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
 }
 
 func (s *Server) scaleTargetForService(ctx context.Context, serviceName, namespace string) error {

--- a/operator/internal/elastiserver/elastiServer.go
+++ b/operator/internal/elastiserver/elastiServer.go
@@ -154,26 +154,26 @@ func (s *Server) crdCacheHandler(w http.ResponseWriter, req *http.Request) {
 	}
 
 	allCRDs := crddirectory.ListAllCRDs()
-	resp := messages.CRDCacheResponse{
-		CRDCache: make(map[string]messages.CRDCacheEntry),
+	resp := messages.ElastiServiceCacheResponse{
+		Services: make(map[string]messages.ElastiServiceEntry),
 	}
 	for key, details := range allCRDs {
 		specJSON, err := json.Marshal(details.Spec)
 		if err != nil {
-			s.logger.Error("Failed to marshal CRD spec", zap.String("key", key), zap.Error(err))
+			s.logger.Error("Failed to marshal ElastiService spec", zap.String("key", key), zap.Error(err))
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 		statusJSON, err := json.Marshal(details.Status)
 		if err != nil {
-			s.logger.Error("Failed to marshal CRD status", zap.String("key", key), zap.Error(err))
+			s.logger.Error("Failed to marshal ElastiService status", zap.String("key", key), zap.Error(err))
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
-		resp.CRDCache[key] = messages.CRDCacheEntry{
-			CRDName: details.CRDName,
-			Spec:    specJSON,
-			Status:  statusJSON,
+		resp.Services[key] = messages.ElastiServiceEntry{
+			Name:   details.CRDName,
+			Spec:   specJSON,
+			Status: statusJSON,
 		}
 	}
 

--- a/pkg/messages/operator.go
+++ b/pkg/messages/operator.go
@@ -8,12 +8,12 @@ type RequestCount struct {
 	Namespace string `json:"namespace"`
 }
 
-type CRDCacheEntry struct {
-	CRDName string          `json:"crdName"`
-	Spec    json.RawMessage `json:"spec"`
-	Status  json.RawMessage `json:"status"`
+type ElastiServiceEntry struct {
+	Name   string          `json:"name"`
+	Spec   json.RawMessage `json:"spec"`
+	Status json.RawMessage `json:"status"`
 }
 
-type CRDCacheResponse struct {
-	CRDCache map[string]CRDCacheEntry `json:"crdCache"`
+type ElastiServiceCacheResponse struct {
+	Services map[string]ElastiServiceEntry `json:"services"`
 }

--- a/pkg/messages/operator.go
+++ b/pkg/messages/operator.go
@@ -1,7 +1,19 @@
 package messages
 
+import "encoding/json"
+
 type RequestCount struct {
 	Count     int    `json:"count"`
 	Svc       string `json:"svc"`
 	Namespace string `json:"namespace"`
+}
+
+type CRDCacheEntry struct {
+	CRDName string          `json:"crdName"`
+	Spec    json.RawMessage `json:"spec"`
+	Status  json.RawMessage `json:"status"`
+}
+
+type CRDCacheResponse struct {
+	CRDCache map[string]CRDCacheEntry `json:"crdCache"`
 }

--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -94,7 +94,7 @@ func main() {
 	k8sUtil := k8shelper.NewOps(logger, config)
 	newOperatorRPC := operator.NewOperatorClient(logger, time.Duration(env.OperatorRetryDuration)*time.Second)
 	newHostManager := hostmanager.NewHostManager(logger, time.Duration(env.TrafficReEnableDuration)*time.Second, env.HeaderForHost)
-	crdCache := crdcache.New(logger, time.Duration(env.CRDCachePollIntervalMinutes)*time.Minute)
+	crdCache := crdcache.New(logger, newOperatorRPC, time.Duration(env.CRDCachePollIntervalMinutes)*time.Minute)
 	crdCache.StartBackground()
 	newTransport := throttler.NewProxyAutoTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
 	newThrottler := throttler.NewThrottler(&throttler.Params{
@@ -118,7 +118,6 @@ func main() {
 		HostManager: newHostManager,
 		Throttler:   newThrottler,
 		Transport:   newTransport,
-		CRDCache:    crdcache.NewProvider(crdCache),
 	})
 
 	// Handle all the incoming requests

--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -13,6 +13,7 @@ import (
 
 	sentryhttp "github.com/getsentry/sentry-go/http"
 
+	"github.com/truefoundry/elasti/resolver/internal/crdcache"
 	"github.com/truefoundry/elasti/resolver/internal/handler"
 	"github.com/truefoundry/elasti/resolver/internal/hostmanager"
 	"github.com/truefoundry/elasti/resolver/internal/operator"
@@ -48,6 +49,8 @@ type config struct {
 	InitialCapacity int `split_words:"true" default:"100"`
 	// HeaderForHost is the header to look for to get the host
 	HeaderForHost string `split_words:"true" default:"Host"`
+	// CRDCachePollIntervalMinutes is the interval in minutes to poll operator for CRD cache
+	CRDCachePollIntervalMinutes int `split_words:"true" default:"5"`
 	// Sentry config
 	SentryDsn string `split_words:"true" default:""`
 	SentryEnv string `envconfig:"SENTRY_ENVIRONMENT" default:""`
@@ -91,6 +94,8 @@ func main() {
 	k8sUtil := k8shelper.NewOps(logger, config)
 	newOperatorRPC := operator.NewOperatorClient(logger, time.Duration(env.OperatorRetryDuration)*time.Second)
 	newHostManager := hostmanager.NewHostManager(logger, time.Duration(env.TrafficReEnableDuration)*time.Second, env.HeaderForHost)
+	crdCache := crdcache.New(logger, time.Duration(env.CRDCachePollIntervalMinutes)*time.Minute)
+	crdCache.StartBackground()
 	newTransport := throttler.NewProxyAutoTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
 	newThrottler := throttler.NewThrottler(&throttler.Params{
 		QueueRetryDuration:      time.Duration(env.QueueRetryDuration) * time.Second,
@@ -113,6 +118,7 @@ func main() {
 		HostManager: newHostManager,
 		Throttler:   newThrottler,
 		Transport:   newTransport,
+		CRDCache:    crdcache.NewProvider(crdCache),
 	})
 
 	// Handle all the incoming requests

--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -149,12 +149,7 @@ func main() {
 	internalServeMux := http.NewServeMux()
 	internalServeMux.Handle("/metrics", promhttp.Handler())
 	internalServeMux.Handle("/queue-status", sentryHandler.HandleFunc(requestHandler.GetQueueStatus))
-<<<<<<< HEAD
 	internalServeMux.Handle("/crd-cache-status", sentryHandler.HandleFunc(requestHandler.GetCRDCacheStatus))
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 14b2891 (feat: add main)
 	internalServeMux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("ok"))

--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -113,6 +113,7 @@ func main() {
 	// Create a handler
 	requestHandler := handler.NewHandler(&handler.Params{
 		Logger:      logger,
+		CRDCache:    crdCache,
 		ReqTimeout:  time.Duration(env.ReqTimeout) * time.Second,
 		OperatorRPC: newOperatorRPC,
 		HostManager: newHostManager,
@@ -148,6 +149,7 @@ func main() {
 	internalServeMux := http.NewServeMux()
 	internalServeMux.Handle("/metrics", promhttp.Handler())
 	internalServeMux.Handle("/queue-status", sentryHandler.HandleFunc(requestHandler.GetQueueStatus))
+	internalServeMux.Handle("/crd-cache-status", sentryHandler.HandleFunc(requestHandler.GetCRDCacheStatus))
 	internalServer := &http.Server{
 		Addr:              internalPort,
 		Handler:           internalServeMux,

--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -149,9 +149,7 @@ func main() {
 	internalServeMux := http.NewServeMux()
 	internalServeMux.Handle("/metrics", promhttp.Handler())
 	internalServeMux.Handle("/queue-status", sentryHandler.HandleFunc(requestHandler.GetQueueStatus))
-<<<<<<< crd-cache
 	internalServeMux.Handle("/crd-cache-status", sentryHandler.HandleFunc(requestHandler.GetCRDCacheStatus))
-=======
 	internalServeMux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("ok"))
@@ -168,7 +166,6 @@ func main() {
 			return
 		}
 	})
->>>>>>> main
 	internalServer := &http.Server{
 		Addr:              internalPort,
 		Handler:           internalServeMux,

--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -149,7 +149,12 @@ func main() {
 	internalServeMux := http.NewServeMux()
 	internalServeMux.Handle("/metrics", promhttp.Handler())
 	internalServeMux.Handle("/queue-status", sentryHandler.HandleFunc(requestHandler.GetQueueStatus))
+<<<<<<< HEAD
 	internalServeMux.Handle("/crd-cache-status", sentryHandler.HandleFunc(requestHandler.GetCRDCacheStatus))
+<<<<<<< HEAD
+=======
+=======
+>>>>>>> 14b2891 (feat: add main)
 	internalServeMux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("ok"))
@@ -166,6 +171,7 @@ func main() {
 			return
 		}
 	})
+
 	internalServer := &http.Server{
 		Addr:              internalPort,
 		Handler:           internalServeMux,

--- a/resolver/internal/crdcache/cache.go
+++ b/resolver/internal/crdcache/cache.go
@@ -1,0 +1,133 @@
+package crdcache
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/truefoundry/elasti/pkg/config"
+	"github.com/truefoundry/elasti/pkg/messages"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultPollInterval = 5 * time.Minute
+	crdCachePath        = "/crd-cache"
+)
+
+type Cache struct {
+	logger       *zap.Logger
+	operatorURL  string
+	pollInterval time.Duration
+	client       *http.Client
+	cache        *sync.Map // key: "namespace/name", value: *messages.CRDCacheEntry
+	stopCh       chan struct{}
+	stopOnce     sync.Once
+}
+
+// New creates a CRD cache that polls the operator every pollInterval.
+func New(logger *zap.Logger, pollInterval time.Duration) *Cache {
+	if pollInterval <= 0 {
+		pollInterval = defaultPollInterval
+	}
+	operatorConfig := config.GetOperatorConfig()
+	operatorHost := operatorConfig.ServiceName + "." + operatorConfig.Namespace + ".svc." + config.GetKubernetesClusterDomain()
+	operatorHostPort := net.JoinHostPort(operatorHost, strconv.Itoa(int(operatorConfig.Port)))
+
+	return &Cache{
+		logger:       logger.With(zap.String("component", "crdcache")),
+		operatorURL:  "http://" + operatorHostPort + crdCachePath,
+		pollInterval: pollInterval,
+		client:       &http.Client{Timeout: 30 * time.Second},
+		cache:        &sync.Map{},
+		stopCh:       make(chan struct{}),
+	}
+}
+
+// Start begins polling the operator for CRD cache updates.
+func (c *Cache) Start() {
+	c.logger.Info("Starting CRD cache poller", zap.Duration("interval", c.pollInterval))
+	c.fetch()
+	ticker := time.NewTicker(c.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.stopCh:
+			c.logger.Info("CRD cache poller stopped")
+			return
+		case <-ticker.C:
+			c.fetch()
+		}
+	}
+}
+
+func (c *Cache) StartBackground() {
+	go c.Start()
+}
+
+func (c *Cache) Stop() {
+	c.stopOnce.Do(func() {
+		close(c.stopCh)
+	})
+}
+
+// fetch retrieves the CRD cache from the operator and updates the local cache.
+func (c *Cache) fetch() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.operatorURL, nil)
+	if err != nil {
+		c.logger.Error("Failed to create CRD cache request", zap.Error(err))
+		return
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.logger.Error("Failed to fetch CRD cache from operator", zap.Error(err))
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		c.logger.Error("CRD cache fetch returned non-OK status", zap.Int("status", resp.StatusCode))
+		return
+	}
+	var cacheResp messages.CRDCacheResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cacheResp); err != nil {
+		c.logger.Error("Failed to decode CRD cache response", zap.Error(err))
+		return
+	}
+
+	// Build new cache then swap atomically to avoid partial reads
+	newCache := &sync.Map{}
+	for k, v := range cacheResp.CRDCache {
+		entry := v
+		newCache.Store(k, &entry)
+	}
+	c.cache = newCache
+	c.logger.Debug("CRD cache updated", zap.Int("count", len(cacheResp.CRDCache)))
+}
+
+// GetCRD returns the cached CRD entry for the given namespaced name (namespace/name).
+func (c *Cache) GetCRD(namespacedName string) (*messages.CRDCacheEntry, bool) {
+	val, ok := c.cache.Load(namespacedName)
+	if !ok {
+		return nil, false
+	}
+	return val.(*messages.CRDCacheEntry), true
+}
+
+// GetCRDByService returns the cached CRD entry for namespace and service name.
+func (c *Cache) GetCRDByService(namespace, service string) (*messages.CRDCacheEntry, bool) {
+	return c.GetCRD(namespace + "/" + service)
+}
+
+type Provider interface {
+	GetCRD(namespacedName string) (*messages.CRDCacheEntry, bool)
+}
+
+func NewProvider(c *Cache) Provider {
+	return c
+}

--- a/resolver/internal/crdcache/cache.go
+++ b/resolver/internal/crdcache/cache.go
@@ -100,3 +100,14 @@ func (c *Cache) GetElastiService(namespacedServiceName string) (*messages.Elasti
 	}
 	return val.(*messages.ElastiServiceEntry), true
 }
+
+func (c *Cache) GetCacheStatus() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	count := 0
+	c.cache.Range(func(key, value any) bool {
+		count++
+		return true
+	})
+	return count
+}

--- a/resolver/internal/crdcache/cache.go
+++ b/resolver/internal/crdcache/cache.go
@@ -115,7 +115,7 @@ func (c *Cache) ListCachedServices() []CachedService {
 	cm := c.cache
 
 	var keys []string
-	cm.Range(func(key, value any) bool {
+	cm.Range(func(key, _ any) bool {
 		keys = append(keys, key.(string))
 		return true
 	})

--- a/resolver/internal/crdcache/cache.go
+++ b/resolver/internal/crdcache/cache.go
@@ -1,48 +1,38 @@
 package crdcache
 
 import (
-	"context"
-	"encoding/json"
-	"net"
-	"net/http"
-	"strconv"
+	"fmt"
 	"sync"
 	"time"
 
-	"github.com/truefoundry/elasti/pkg/config"
 	"github.com/truefoundry/elasti/pkg/messages"
+	"github.com/truefoundry/elasti/resolver/internal/operator"
 	"go.uber.org/zap"
 )
 
-const (
-	defaultPollInterval = 5 * time.Minute
-	crdCachePath        = "/crd-cache"
-)
+const defaultPollInterval = 5 * time.Minute
 
 type Cache struct {
 	logger       *zap.Logger
-	operatorURL  string
+	operatorRPC  *operator.Client
 	pollInterval time.Duration
-	client       *http.Client
-	cache        *sync.Map // key: "namespace/name", value: *messages.CRDCacheEntry
-	stopCh       chan struct{}
-	stopOnce     sync.Once
+
+	mu    sync.RWMutex
+	cache *sync.Map // key: "namespace/service-name", value: *messages.ElastiServiceEntry
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
-// New creates a CRD cache that polls the operator every pollInterval.
-func New(logger *zap.Logger, pollInterval time.Duration) *Cache {
+// New creates a Cache that polls the operator every pollInterval.
+func New(logger *zap.Logger, operatorRPC *operator.Client, pollInterval time.Duration) *Cache {
 	if pollInterval <= 0 {
 		pollInterval = defaultPollInterval
 	}
-	operatorConfig := config.GetOperatorConfig()
-	operatorHost := operatorConfig.ServiceName + "." + operatorConfig.Namespace + ".svc." + config.GetKubernetesClusterDomain()
-	operatorHostPort := net.JoinHostPort(operatorHost, strconv.Itoa(int(operatorConfig.Port)))
-
 	return &Cache{
 		logger:       logger.With(zap.String("component", "crdcache")),
-		operatorURL:  "http://" + operatorHostPort + crdCachePath,
+		operatorRPC:  operatorRPC,
 		pollInterval: pollInterval,
-		client:       &http.Client{Timeout: 30 * time.Second},
 		cache:        &sync.Map{},
 		stopCh:       make(chan struct{}),
 	}
@@ -50,17 +40,21 @@ func New(logger *zap.Logger, pollInterval time.Duration) *Cache {
 
 // Start begins polling the operator for CRD cache updates.
 func (c *Cache) Start() {
-	c.logger.Info("Starting CRD cache poller", zap.Duration("interval", c.pollInterval))
-	c.fetch()
+	c.logger.Info("Starting ElastiService cache poller", zap.Duration("interval", c.pollInterval))
+	if err := c.fetch(); err != nil {
+		c.logger.Error("Initial ElastiService cache fetch failed", zap.Error(err))
+	}
 	ticker := time.NewTicker(c.pollInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-c.stopCh:
-			c.logger.Info("CRD cache poller stopped")
+			c.logger.Info("ElastiService cache poller stopped")
 			return
 		case <-ticker.C:
-			c.fetch()
+			if err := c.fetch(); err != nil {
+				c.logger.Error("ElastiService cache fetch failed", zap.Error(err))
+			}
 		}
 	}
 }
@@ -70,64 +64,39 @@ func (c *Cache) StartBackground() {
 }
 
 func (c *Cache) Stop() {
-	c.stopOnce.Do(func() {
-		close(c.stopCh)
-	})
+	c.stopOnce.Do(func() { close(c.stopCh) })
 }
 
-// fetch retrieves the CRD cache from the operator and updates the local cache.
-func (c *Cache) fetch() {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.operatorURL, nil)
+// fetch retrieves the ElastiService cache from the operator and atomically replaces the local copy.
+func (c *Cache) fetch() error {
+	resp, err := c.operatorRPC.GetElastiServiceCache()
 	if err != nil {
-		c.logger.Error("Failed to create CRD cache request", zap.Error(err))
-		return
-	}
-	resp, err := c.client.Do(req)
-	if err != nil {
-		c.logger.Error("Failed to fetch CRD cache from operator", zap.Error(err))
-		return
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		c.logger.Error("CRD cache fetch returned non-OK status", zap.Int("status", resp.StatusCode))
-		return
-	}
-	var cacheResp messages.CRDCacheResponse
-	if err := json.NewDecoder(resp.Body).Decode(&cacheResp); err != nil {
-		c.logger.Error("Failed to decode CRD cache response", zap.Error(err))
-		return
+		return fmt.Errorf("fetch: %w", err)
 	}
 
-	// Build new cache then swap atomically to avoid partial reads
 	newCache := &sync.Map{}
-	for k, v := range cacheResp.CRDCache {
+	for k, v := range resp.Services {
 		entry := v
 		newCache.Store(k, &entry)
 	}
+
+	c.mu.Lock()
 	c.cache = newCache
-	c.logger.Debug("CRD cache updated", zap.Int("count", len(cacheResp.CRDCache)))
+	c.mu.Unlock()
+
+	c.logger.Debug("ElastiService cache updated", zap.Int("count", len(resp.Services)))
+	return nil
 }
 
-// GetCRD returns the cached CRD entry for the given namespaced name (namespace/name).
-func (c *Cache) GetCRD(namespacedName string) (*messages.CRDCacheEntry, bool) {
-	val, ok := c.cache.Load(namespacedName)
+// GetElastiService returns the cached entry for "namespace/service-name".
+func (c *Cache) GetElastiService(namespacedServiceName string) (*messages.ElastiServiceEntry, bool) {
+	c.mu.RLock()
+	cm := c.cache
+	c.mu.RUnlock()
+
+	val, ok := cm.Load(namespacedServiceName)
 	if !ok {
 		return nil, false
 	}
-	return val.(*messages.CRDCacheEntry), true
-}
-
-// GetCRDByService returns the cached CRD entry for namespace and service name.
-func (c *Cache) GetCRDByService(namespace, service string) (*messages.CRDCacheEntry, bool) {
-	return c.GetCRD(namespace + "/" + service)
-}
-
-type Provider interface {
-	GetCRD(namespacedName string) (*messages.CRDCacheEntry, bool)
-}
-
-func NewProvider(c *Cache) Provider {
-	return c
+	return val.(*messages.ElastiServiceEntry), true
 }

--- a/resolver/internal/crdcache/cache.go
+++ b/resolver/internal/crdcache/cache.go
@@ -2,6 +2,7 @@ package crdcache
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -101,13 +102,32 @@ func (c *Cache) GetElastiService(namespacedServiceName string) (*messages.Elasti
 	return val.(*messages.ElastiServiceEntry), true
 }
 
-func (c *Cache) GetCacheStatus() int {
+// CachedService is one ElastiService in the resolver's local cache (key is namespace/service-name).
+type CachedService struct {
+	NamespacedName string `json:"namespacedName"`
+	messages.ElastiServiceEntry
+}
+
+// ListCachedServices returns a stable snapshot of cached ElastiService entries.
+func (c *Cache) ListCachedServices() []CachedService {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	count := 0
-	c.cache.Range(func(key, value any) bool {
-		count++
+	cm := c.cache
+
+	var keys []string
+	cm.Range(func(key, value any) bool {
+		keys = append(keys, key.(string))
 		return true
 	})
-	return count
+	sort.Strings(keys)
+	out := make([]CachedService, 0, len(keys))
+	for _, k := range keys {
+		v, ok := cm.Load(k)
+		if !ok {
+			continue
+		}
+		entry := *(v.(*messages.ElastiServiceEntry))
+		out = append(out, CachedService{NamespacedName: k, ElastiServiceEntry: entry})
+	}
+	return out
 }

--- a/resolver/internal/crdcache/cache_test.go
+++ b/resolver/internal/crdcache/cache_test.go
@@ -1,0 +1,168 @@
+package crdcache
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/truefoundry/elasti/pkg/messages"
+	"github.com/truefoundry/elasti/resolver/internal/operator"
+	"go.uber.org/zap"
+)
+
+// swappableHandler lets tests replace the HTTP handler mid-test.
+type swappableHandler struct {
+	mu sync.RWMutex
+	fn http.HandlerFunc
+}
+
+func (h *swappableHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.mu.RLock()
+	fn := h.fn
+	h.mu.RUnlock()
+	fn(w, r)
+}
+
+func (h *swappableHandler) set(fn http.HandlerFunc) {
+	h.mu.Lock()
+	h.fn = fn
+	h.mu.Unlock()
+}
+
+func respondWith(resp *messages.ElastiServiceCacheResponse) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	}
+}
+
+func newTestCache(t *testing.T, server *httptest.Server, interval time.Duration) *Cache {
+	t.Helper()
+	rpc := operator.NewOperatorClientWithURL(zap.NewNop(), 0, server.URL)
+	return New(zap.NewNop(), rpc, interval)
+}
+
+// TestFetchPopulatesCache checks that a successful fetch stores entries.
+func TestFetchPopulatesCache(t *testing.T) {
+	srv := httptest.NewServer(respondWith(&messages.ElastiServiceCacheResponse{
+		Services: map[string]messages.ElastiServiceEntry{
+			"default/my-svc": {Name: "my-elastiservice", Spec: json.RawMessage(`{"service":"my-svc"}`)},
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestCache(t, srv, time.Minute)
+	if err := c.fetch(); err != nil {
+		t.Fatalf("fetch() unexpected error: %v", err)
+	}
+
+	entry, ok := c.GetElastiService("default/my-svc")
+	if !ok {
+		t.Fatal("expected entry to be in cache")
+	}
+	if entry.Name != "my-elastiservice" {
+		t.Errorf("Name = %q; want %q", entry.Name, "my-elastiservice")
+	}
+}
+
+// TestFetchErrorDoesNotClearCache checks that a failed fetch leaves the previous cache intact.
+func TestFetchErrorDoesNotClearCache(t *testing.T) {
+	h := &swappableHandler{}
+	h.set(respondWith(&messages.ElastiServiceCacheResponse{
+		Services: map[string]messages.ElastiServiceEntry{
+			"ns/svc": {Name: "es"},
+		},
+	}))
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	c := newTestCache(t, srv, time.Minute)
+	if err := c.fetch(); err != nil {
+		t.Fatalf("first fetch error: %v", err)
+	}
+
+	// Inject a server error.
+	h.set(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "operator down", http.StatusInternalServerError)
+	})
+
+	if err := c.fetch(); err == nil {
+		t.Fatal("expected error from fetch, got nil")
+	}
+
+	// Previous data must still be accessible.
+	_, ok := c.GetElastiService("ns/svc")
+	if !ok {
+		t.Fatal("cache was cleared on error; expected previous entry to survive")
+	}
+}
+
+// TestGetElastiServiceMiss checks that missing keys return false.
+func TestGetElastiServiceMiss(t *testing.T) {
+	srv := httptest.NewServer(respondWith(&messages.ElastiServiceCacheResponse{
+		Services: map[string]messages.ElastiServiceEntry{},
+	}))
+	defer srv.Close()
+
+	c := newTestCache(t, srv, time.Minute)
+	_ = c.fetch()
+
+	_, ok := c.GetElastiService("ns/missing")
+	if ok {
+		t.Fatal("expected miss for unknown key")
+	}
+}
+
+// TestConcurrentFetchAndGet exercises the RWMutex guarding the cache pointer.
+func TestConcurrentFetchAndGet(t *testing.T) {
+	srv := httptest.NewServer(respondWith(&messages.ElastiServiceCacheResponse{
+		Services: map[string]messages.ElastiServiceEntry{
+			"ns/svc": {Name: "es"},
+		},
+	}))
+	defer srv.Close()
+
+	c := newTestCache(t, srv, time.Minute)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = c.fetch()
+		}()
+		go func() {
+			defer wg.Done()
+			c.GetElastiService("ns/svc")
+		}()
+	}
+	wg.Wait()
+}
+
+// TestStopCancelsPoller checks that Stop() prevents further ticks.
+func TestStopCancelsPoller(t *testing.T) {
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		json.NewEncoder(w).Encode(&messages.ElastiServiceCacheResponse{ //nolint:errcheck
+			Services: map[string]messages.ElastiServiceEntry{},
+		})
+	}))
+	defer srv.Close()
+
+	c := newTestCache(t, srv, 50*time.Millisecond)
+	c.StartBackground()
+	time.Sleep(160 * time.Millisecond)
+	c.Stop()
+
+	callsAfterStop := calls.Load()
+	time.Sleep(150 * time.Millisecond)
+
+	if got := calls.Load(); got != callsAfterStop {
+		t.Errorf("calls continued after Stop(): before=%d after=%d", callsAfterStop, got)
+	}
+}

--- a/resolver/internal/crdcache/cache_test.go
+++ b/resolver/internal/crdcache/cache_test.go
@@ -67,6 +67,14 @@ func TestFetchPopulatesCache(t *testing.T) {
 	if entry.Name != "my-elastiservice" {
 		t.Errorf("Name = %q; want %q", entry.Name, "my-elastiservice")
 	}
+
+	list := c.ListCachedServices()
+	if len(list) != 1 {
+		t.Fatalf("ListCachedServices len = %d; want 1", len(list))
+	}
+	if list[0].NamespacedName != "default/my-svc" || list[0].Name != "my-elastiservice" {
+		t.Errorf("ListCachedServices[0] = %+v; want default/my-svc + my-elastiservice", list[0])
+	}
 }
 
 // TestFetchErrorDoesNotClearCache checks that a failed fetch leaves the previous cache intact.

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -278,9 +278,13 @@ func NewBufferPool() httputil.BufferPool {
 }
 
 func (h *Handler) GetCRDCacheStatus(w http.ResponseWriter, r *http.Request) {
-	cacheStatus := h.crdCache.GetCacheStatus()
-	response := Response{
-		Message: fmt.Sprintf("CRD cache has %d services in it", cacheStatus),
+	services := h.crdCache.ListCachedServices()
+	response := struct {
+		Count    int                      `json:"count"`
+		Services []crdcache.CachedService `json:"services"`
+	}{
+		Count:    len(services),
+		Services: services,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/truefoundry/elasti/resolver/internal/crdcache"
 	"github.com/truefoundry/elasti/resolver/internal/prom"
 	"github.com/truefoundry/elasti/resolver/internal/throttler"
 
@@ -30,6 +31,7 @@ type (
 		timeout     time.Duration
 		operatorRPC Operator
 		hostManager HostManager
+		crdCache    crdcache.Provider
 	}
 
 	// Params is the configuration for the handler
@@ -40,6 +42,7 @@ type (
 		HostManager HostManager
 		Throttler   *throttler.Throttler
 		Transport   http.RoundTripper
+		CRDCache    crdcache.Provider
 	}
 
 	// Operator is to communicate with the operator
@@ -64,6 +67,7 @@ func NewHandler(hc *Params) *Handler {
 		timeout:     hc.ReqTimeout,
 		operatorRPC: hc.OperatorRPC,
 		hostManager: hc.HostManager,
+		crdCache:    hc.CRDCache,
 	}
 }
 

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/truefoundry/elasti/resolver/internal/crdcache"
 	"github.com/truefoundry/elasti/resolver/internal/prom"
 	"github.com/truefoundry/elasti/resolver/internal/throttler"
 
@@ -28,6 +29,7 @@ type (
 		transport   http.RoundTripper
 		bufferPool  httputil.BufferPool
 		timeout     time.Duration
+		crdCache    *crdcache.Cache
 		operatorRPC Operator
 		hostManager HostManager
 	}
@@ -40,6 +42,7 @@ type (
 		HostManager HostManager
 		Throttler   *throttler.Throttler
 		Transport   http.RoundTripper
+		CRDCache    *crdcache.Cache
 	}
 
 	// Operator is to communicate with the operator
@@ -62,6 +65,7 @@ func NewHandler(hc *Params) *Handler {
 		transport:   hc.Transport,
 		bufferPool:  NewBufferPool(),
 		timeout:     hc.ReqTimeout,
+		crdCache:    hc.CRDCache,
 		operatorRPC: hc.OperatorRPC,
 		hostManager: hc.HostManager,
 	}
@@ -270,5 +274,20 @@ func NewBufferPool() httputil.BufferPool {
 		// allocation when creating the slices. They are implicitly created in the
 		// Get function below.
 		pool: &sync.Pool{},
+	}
+}
+
+func (h *Handler) GetCRDCacheStatus(w http.ResponseWriter, r *http.Request) {
+	cacheStatus := h.crdCache.GetCacheStatus()
+	response := Response{
+		Message: fmt.Sprintf("CRD cache has %d services in it", cacheStatus),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	err := json.NewEncoder(w).Encode(response)
+	if err != nil {
+		h.logger.Error("Failed to encode CRD cache status response", zap.Error(err))
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
 	}
 }

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/truefoundry/elasti/resolver/internal/crdcache"
 	"github.com/truefoundry/elasti/resolver/internal/prom"
 	"github.com/truefoundry/elasti/resolver/internal/throttler"
 
@@ -31,7 +30,6 @@ type (
 		timeout     time.Duration
 		operatorRPC Operator
 		hostManager HostManager
-		crdCache    crdcache.Provider
 	}
 
 	// Params is the configuration for the handler
@@ -42,7 +40,6 @@ type (
 		HostManager HostManager
 		Throttler   *throttler.Throttler
 		Transport   http.RoundTripper
-		CRDCache    crdcache.Provider
 	}
 
 	// Operator is to communicate with the operator
@@ -67,7 +64,6 @@ func NewHandler(hc *Params) *Handler {
 		timeout:     hc.ReqTimeout,
 		operatorRPC: hc.OperatorRPC,
 		hostManager: hc.HostManager,
-		crdCache:    hc.CRDCache,
 	}
 }
 

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -277,7 +277,7 @@ func NewBufferPool() httputil.BufferPool {
 	}
 }
 
-func (h *Handler) GetCRDCacheStatus(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) GetCRDCacheStatus(w http.ResponseWriter, _ *http.Request) {
 	services := h.crdCache.ListCachedServices()
 	response := struct {
 		Count    int                      `json:"count"`

--- a/resolver/internal/operator/RPCClient.go
+++ b/resolver/internal/operator/RPCClient.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -17,6 +18,8 @@ import (
 
 	"sync"
 )
+
+const elastiServiceCacheEndpoint = "/crd-cache"
 
 // Client is to communicate with the operator
 type Client struct {
@@ -39,10 +42,15 @@ func NewOperatorClient(logger *zap.Logger, retryDuration time.Duration) *Client 
 	operatorHost := operatorConfig.ServiceName + "." + operatorConfig.Namespace + ".svc." + config.GetKubernetesClusterDomain()
 	operatorHostPort := net.JoinHostPort(operatorHost, strconv.Itoa(int(operatorConfig.Port)))
 
+	return NewOperatorClientWithURL(logger, retryDuration, "http://"+operatorHostPort)
+}
+
+// NewOperatorClientWithURL creates a Client pointing at a specific base URL.
+func NewOperatorClientWithURL(logger *zap.Logger, retryDuration time.Duration, baseURL string) *Client {
 	return &Client{
 		logger:                  logger.With(zap.String("component", "operatorRPC")),
 		retryDuration:           retryDuration,
-		operatorURL:             "http://" + operatorHostPort,
+		operatorURL:             baseURL,
 		incomingRequestEndpoint: "/informer/incoming-request",
 		client:                  http.Client{},
 	}
@@ -99,6 +107,33 @@ func (o *Client) SendIncomingRequestInfo(ns, svc string) {
 	}
 	prom.OperatorRPCCounter.WithLabelValues("").Inc()
 	o.logger.Info("Request sent to controller", zap.Int("statusCode", resp.StatusCode), zap.Any("body", resp.Body))
+}
+
+// GetElastiServiceCache fetches the full ElastiService cache from the operator.
+func (o *Client) GetElastiServiceCache() (*messages.ElastiServiceCacheResponse, error) {
+	url := o.operatorURL + elastiServiceCacheEndpoint
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("GetElastiServiceCache: failed to create request: %w", err)
+	}
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GetElastiServiceCache: request failed: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			o.logger.Error("GetElastiServiceCache: failed to close response body", zap.Error(closeErr))
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("GetElastiServiceCache: operator returned status %d: %s", resp.StatusCode, string(body))
+	}
+	var result messages.ElastiServiceCacheResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("GetElastiServiceCache: failed to decode response: %w", err)
+	}
+	return &result, nil
 }
 
 func (o *Client) releaseMutexForServiceRPC(service string) {


### PR DESCRIPTION
## Description
Implements a crd cache list API in operator and periodically fetches it from resolver to maintain a crd cache for the resolver.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
- [ ] A PR is open to update the helm chart (link)[https://github.com/KubeElasti/KubeElasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made
