### PR TITLE
release: v0.1.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ## Unreleased
 
+
+## v0.1.23 (2026-04-15)
+
 ### Breaking Changes
 
 * add probeResponse to ElastiService, without scale up of the target service by `@ramantehlan`in 
@@ -16,6 +19,8 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 * docs: add project governance document and link it from contributor-facing docs
 * lint fixes: update lint version to v2 in github workflow & fix existing issues by `@ramantehlan` in [#265](https://github.com/KubeElasti/KubeElasti/pull/265)
+* Update github issue and PR forms, updated raw images and PR/Issue greeting message by `@ramantehlan` in [#264](https://github.com/KubeElasti/KubeElasti/pull/264)
+
 
 ## v0.1.22 (2026-04-01)
 

--- a/charts/elasti/Chart.yaml
+++ b/charts/elasti/Chart.yaml
@@ -3,8 +3,8 @@ name: elasti
 description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionality when there is no traffic and automatic scale up to 1 when traffic arrives.
 icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/images/logo/logo_theme_200x200.png
 type: application
-version: 0.1.22
-appVersion: "0.1.22"
+version: 0.1.23
+appVersion: "0.1.23"
 # kubeVersion: ">=1.25.0-0"
 home: https://kubeelasti.dev
 sources:

--- a/charts/elasti/README.md
+++ b/charts/elasti/README.md
@@ -36,7 +36,7 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 | `elastiController.manager.podSecurityContext`       | pod security context                                   | `{}`                         |
 | `elastiController.manager.image.registry`           | registry to use for the deployment                     | `""`                         |
 | `elastiController.manager.image.repository`         | repository to use for the deployment                   | `tfy-images/elasti-operator` |
-| `elastiController.manager.image.tag`                | tag to use for the deployment                          | `0.1.22`                     |
+| `elastiController.manager.image.tag`                | tag to use for the deployment                          | `0.1.23`                     |
 | `elastiController.manager.imagePullPolicy`          | image pull policy                                      | `IfNotPresent`               |
 | `elastiController.manager.resources`                | resources to use for the deployment                    | `{}`                         |
 | `elastiController.manager.sentry.enabled`           | whether to enable sentry                               | `false`                      |
@@ -68,7 +68,7 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 | `elastiResolver.proxy.env`                                  | environment to use for the deployment                       | `{}`                         |
 | `elastiResolver.proxy.image.registry`                       | registry to use for the deployment                          | `""`                         |
 | `elastiResolver.proxy.image.repository`                     | repository to use for the deployment                        | `tfy-images/elasti-resolver` |
-| `elastiResolver.proxy.image.tag`                            | tag to use for the deployment                               | `0.1.22`                     |
+| `elastiResolver.proxy.image.tag`                            | tag to use for the deployment                               | `0.1.23`                     |
 | `elastiResolver.proxy.imagePullPolicy`                      | image pull policy                                           | `IfNotPresent`               |
 | `elastiResolver.proxy.resources`                            | resources to use for the deployment                         | `{}`                         |
 | `elastiResolver.proxy.containerSecurityContext`             | container security context                                  | `{}`                         |

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -87,7 +87,7 @@ elastiController:
       repository: tfy-images/elasti-operator
       ## @param elastiController.manager.image.tag tag to use for the deployment
       ##
-      tag: 0.1.22
+      tag: 0.1.23
     ## @param elastiController.manager.imagePullPolicy image pull policy
     ##
     imagePullPolicy: IfNotPresent
@@ -204,7 +204,7 @@ elastiResolver:
       repository: tfy-images/elasti-resolver
       ## @param elastiResolver.proxy.image.tag tag to use for the deployment
       ##
-      tag: 0.1.22
+      tag: 0.1.23
     ## @param elastiResolver.proxy.imagePullPolicy image pull policy
     ##
     imagePullPolicy: IfNotPresent

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -11,11 +11,11 @@ entries:
       artifacthub.io/operator: "true"
     apiVersion: v2
     appVersion: 0.1.23
-    created: "2026-04-15T21:47:39.503278832Z"
+    created: "2026-04-15T22:27:09.627357764Z"
     description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
       functionality when there is no traffic and automatic scale up to 1 when traffic
       arrives.
-    digest: 1e25c077ab7797be56146e333e26ce71c3aee5a656cb8a795ec3e85bc3288aff
+    digest: a02f9e132660d1d459c8ded1f749664e8f2e33da3721c854db1a1defe344c9d2
     home: https://kubeelasti.dev
     icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/images/logo/logo_theme_200x200.png
     keywords:
@@ -98,4 +98,4 @@ entries:
     urls:
     - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.20/elasti-0.1.20.tgz
     version: 0.1.20
-generated: "2026-04-15T21:47:39.502142216Z"
+generated: "2026-04-15T22:27:09.626283114Z"

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -10,6 +10,35 @@ entries:
           url: https://slack.cncf.io/
       artifacthub.io/operator: "true"
     apiVersion: v2
+    appVersion: 0.1.23
+    created: "2026-04-15T21:47:39.503278832Z"
+    description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
+      functionality when there is no traffic and automatic scale up to 1 when traffic
+      arrives.
+    digest: 1e25c077ab7797be56146e333e26ce71c3aee5a656cb8a795ec3e85bc3288aff
+    home: https://kubeelasti.dev
+    icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/images/logo/logo_theme_200x200.png
+    keywords:
+    - Scale-to-zero
+    - Operator
+    - Cloud Native
+    - Autoscaling
+    name: elasti
+    sources:
+    - https://github.com/KubeElasti/KubeElasti
+    type: application
+    urls:
+    - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.23/elasti-0.1.23.tgz
+    version: 0.1.23
+  - annotations:
+      artifacthub.io/license: MIT
+      artifacthub.io/links: |
+        - name: Source
+          url: https://github.com/KubeElasti/KubeElasti
+        - name: CNCF Slack (#kubeelasti)
+          url: https://slack.cncf.io/
+      artifacthub.io/operator: "true"
+    apiVersion: v2
     appVersion: 0.1.22
     created: "2026-04-01T09:48:23.006016817Z"
     description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
@@ -69,4 +98,4 @@ entries:
     urls:
     - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.20/elasti-0.1.20.tgz
     version: 0.1.20
-generated: "2026-04-01T09:48:23.004938871Z"
+generated: "2026-04-15T21:47:39.502142216Z"


### PR DESCRIPTION
### Breaking Changes

* add probeResponse to ElastiService, without scale up of the target service by `@ramantehlan`in 

### Other

* docs: add project governance document and link it from contributor-facing docs
* lint fixes: update lint version to v2 in github workflow & fix existing issues by `@ramantehlan` in [#265](https://github.com/KubeElasti/KubeElasti/pull/265)
* Update github issue and PR forms, updated raw images and PR/Issue greeting message by `@ramantehlan` in [#264](https://github.com/KubeElasti/KubeElasti/pull/264)
