### PR TITLE
docs: document host-header routing requirement for elasti

### DIFF
--- a/docs/src/arch-resolver.md
+++ b/docs/src/arch-resolver.md
@@ -44,3 +44,40 @@ flowchart LR
   Obs -.-> Prom["Prometheus"]
 
 ```
+
+## Request Routing
+
+The resolver identifies the target service by reading a single header on each
+incoming request. Two things decide which header is read:
+
+- By default, the resolver binary reads the standard HTTP `Host` header
+  (`resolver/cmd/main.go:51`, `HeaderForHost string ... default:"Host"`).
+- The shipped Helm chart overrides that default to `X-Envoy-Decorator-Operation`
+  (`charts/elasti/values.yaml`, `elastiResolver.proxy.env.headerForHost`) so
+  that deployments fronted by Envoy, Istio, or similar proxies that rewrite the
+  Host header keep working.
+
+Whichever header is selected, its value is parsed into `namespace` and
+`service` by `GetHost` in `hostmanager.go` and used to look up the target
+service to forward the request to.
+
+This has a practical consequence. Whatever routes traffic to the resolver,
+whether an Ingress controller, a service mesh, a `Service` selector, or a
+direct client, must arrive at the resolver with a header value that matches
+the target service's in-cluster FQDN format (for example,
+`target-deployment.target.svc.cluster.local`). If the header does not match,
+the resolver cannot tell which service the request was meant for and will not
+forward the request.
+
+The ingress example in
+[Getting Started, Setup](./gs-setup.md#3-deploy-a-target-application)
+shows one way to satisfy this: the NGINX annotation
+`nginx.ingress.kubernetes.io/upstream-vhost` rewrites the Host header to the
+service FQDN before the request reaches the resolver.
+
+To use a different header (for example, a custom one set by your edge proxy),
+override the Helm value at install time:
+
+```shell
+--set elastiResolver.proxy.env.headerForHost=X-My-Custom-Host
+```

--- a/docs/src/gs-setup.md
+++ b/docs/src/gs-setup.md
@@ -175,6 +175,13 @@ spec:
                   number: 80
 ```
 
+The `nginx.ingress.kubernetes.io/upstream-vhost` annotation above is
+important for elasti: it sets the `Host` header on the request NGINX
+forwards upstream, and the resolver reads that header to decide which
+target service to route to. See
+[Resolver Architecture > Request Routing](./arch-resolver.md#request-routing)
+for details on how routing works and how to override the header.
+
 Apply it:
 
 ```bash


### PR DESCRIPTION
## Description

Documents that elasti's resolver identifies the target service by reading a single header on each incoming request. Adds a "Request Routing" section to `docs/src/arch-resolver.md` and a short note next to the NGINX `upstream-vhost` annotation in `docs/src/gs-setup.md` that was already relying on this behavior without explaining it.

Fixes #236

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] Rendered both edited pages locally to confirm Markdown parses and the new anchor links (`arch-resolver.md#request-routing`, `gs-setup.md#3-deploy-a-target-application`) resolve correctly.
- [x] Cross-checked every code claim in the new section against the source:
  - Default header: `resolver/cmd/main.go:51` (`HeaderForHost string ... default:"Host"`)
  - Helm override: `charts/elasti/values.yaml:186` (`headerForHost: X-Envoy-Decorator-Operation`)
  - Lookup logic: `resolver/internal/hostmanager/hostManager.go:40-55` (`GetHost` reads `req.Host` by default or `req.Header[hm.headerForHost]` when overridden)
  - Existing ingress example: `docs/src/gs-setup.md:163` (the `nginx.ingress.kubernetes.io/upstream-vhost` annotation the note now explains)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] A PR is open to update the helm chart if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made

Docs-only change. No code, no tests, no helm chart values changed, so the test/helm/CHANGELOG boxes are not applicable. Let me know if you'd like a CHANGELOG entry anyway.

_This contribution was developed with AI assistance (Claude Code)._
