### PR TITLE
fix: retry resolver dial on connection refused to avoid 502 on scale-from-zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ## Unreleased
 
+### Fixes
+
+* fix: retry the resolver backoff dialer on "connection refused" (not only on timeouts), avoiding a 502 on the first request after scale-from-zero when the target pod or kube-proxy route is not ready yet by `@sandrotaje`
+
 ## v0.1.24 (2026-05-29)
 
 ### Fixes

--- a/resolver/internal/throttler/transport.go
+++ b/resolver/internal/throttler/transport.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"syscall"
 	"time"
 
 	"golang.org/x/net/http2"
@@ -92,7 +93,15 @@ func dialBackOffHelper(ctx context.Context, network, address string, bo wait.Bac
 		}
 		if err != nil {
 			var errNet net.Error
-			if errors.As(err, &errNet) && errNet.Timeout() {
+			isTimeout := errors.As(err, &errNet) && errNet.Timeout()
+			// "connection refused" is expected during a scale-from-zero: the
+			// target pod may not be accepting connections yet, or kube-proxy
+			// may not have programmed the route to the freshly-ready endpoint.
+			// Retrying within the backoff window (instead of failing fast)
+			// avoids surfacing a 502 to the client on the first request after
+			// wake-up.
+			isConnRefused := errors.Is(err, syscall.ECONNREFUSED)
+			if isTimeout || isConnRefused {
 				if bo.Steps < 1 {
 					break
 				}

--- a/resolver/internal/throttler/transport_test.go
+++ b/resolver/internal/throttler/transport_test.go
@@ -1,0 +1,88 @@
+package throttler
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// reservedRefusedAddr returns a loopback address that refuses connections: it
+// briefly binds a listener to obtain a free port and then closes it, so dials
+// to the returned address fail with "connection refused" until something binds
+// the port again.
+func reservedRefusedAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve a port: %v", err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("failed to close the reservation listener: %v", err)
+	}
+	return addr
+}
+
+// TestDialBackOffHelper_RetriesConnectionRefusedThenConnects reproduces the
+// scale-from-zero scenario: the target is not yet accepting connections (so the
+// dial is refused), and starts serving shortly after. The dialer must retry the
+// refused dials within its backoff window and ultimately connect, rather than
+// failing fast (which surfaces as a 502 to the client).
+func TestDialBackOffHelper_RetriesConnectionRefusedThenConnects(t *testing.T) {
+	addr := reservedRefusedAddr(t)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	lnCh := make(chan net.Listener, 1)
+	go func() {
+		defer wg.Done()
+		// Start serving after a delay so the first dials are refused.
+		time.Sleep(150 * time.Millisecond)
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			lnCh <- nil
+			return
+		}
+		lnCh <- l
+	}()
+
+	bo := wait.Backoff{Duration: 20 * time.Millisecond, Factor: 1.2, Jitter: 0.1, Steps: 30}
+	conn, err := dialBackOffHelper(context.Background(), "tcp", addr, bo, nil)
+	wg.Wait()
+
+	ln := <-lnCh
+	if ln == nil {
+		t.Skip("could not re-bind the reserved port; environment-dependent")
+	}
+	defer ln.Close()
+
+	if err != nil {
+		t.Fatalf("expected dial to succeed after retrying connection refused, got: %v", err)
+	}
+	if conn == nil {
+		t.Fatal("expected a non-nil connection")
+	}
+	_ = conn.Close()
+}
+
+// TestDialBackOffHelper_ReturnsErrorWhenAlwaysRefused ensures the retry budget
+// is bounded: when nothing ever listens, the dialer still gives up and returns
+// an error within a reasonable time.
+func TestDialBackOffHelper_ReturnsErrorWhenAlwaysRefused(t *testing.T) {
+	addr := reservedRefusedAddr(t)
+
+	bo := wait.Backoff{Duration: 10 * time.Millisecond, Factor: 1.2, Jitter: 0.1, Steps: 3}
+	start := time.Now()
+	conn, err := dialBackOffHelper(context.Background(), "tcp", addr, bo, nil)
+	if err == nil {
+		_ = conn.Close()
+		t.Fatal("expected an error when the connection is always refused")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("dial retry budget was not bounded, took: %v", elapsed)
+	}
+}


### PR DESCRIPTION
## Description

A large fraction of the **first** request after a scale-from-zero returns **HTTP 502**, even though the target pod comes up healthy. The resolver logs:

```
reverse proxy error {"error": "dialBackOffHelper: dial tcp <pod-ip>:<port>: connect: connection refused", "url": "http://elasti-<svc>-pvt-....svc.cluster.local/"}
```

**Root cause:** in `resolver/internal/throttler/throttler.go`, `Try()` re-enqueues while the target EndpointSlice is *not* ready, but once it considers the endpoint active it makes exactly **one** proxy attempt. That attempt uses the backoff dialer `dialBackOffHelper` (`resolver/internal/throttler/transport.go`), which **only retries on dial timeouts** and returns immediately on every other error:

```go
if errors.As(err, &errNet) && errNet.Timeout() { /* retry */ }
return nil, fmt.Errorf("dialBackOffHelper: %w", err) // connection refused returns here, no retry
```

During scale-from-zero there is a short window where the EndpointSlice is already `Ready` (so the throttler proceeds) but the connection is still refused — the container isn't accepting connections yet, or kube-proxy hasn't finished programming the route to the freshly-ready endpoint. Since `connection refused` (`ECONNREFUSED`) isn't a timeout, the dialer fails fast, the proxy returns a **502**, and the throttler doesn't re-enqueue. A target readiness probe doesn't help (it only shifts *when* the endpoint becomes Ready; the refused window is after that), and gateways that don't add their own upstream retries (e.g. Pomerium) pass the 502 straight to the client.

**Fix:** retry on `connection refused` within the existing backoff window, mirroring the timeout handling. The retry stays at the dial layer (before any response is committed), so no 502 is written while the backend is still coming up. The retry budget remains bounded by the existing `wait.Backoff` steps.

Fixes # (no dedicated issue) — **Related to #280**. This addresses the *first-request / connection-refused / 502* facet at the dial layer; #280 describes the complementary *post-first-request / reconvergence / 408* facet (proxy disabled immediately after the first success while routing converges).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] New unit tests in `resolver/internal/throttler/transport_test.go` (the package had none): one asserts the dialer retries `connection refused` and connects once a listener comes up; one asserts the retry budget stays bounded when the connection is always refused.
- [x] `cd resolver && go test ./internal/throttler/... -race` passes; `go vet ./...` and `go build ./...` clean for the resolver module.
- Reproduced the original 502 (~50% in-cluster, ~37% through an ingress) before the change; with the change the first request is held until the backend is reachable.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] A PR is open to update the helm chart (N/A — resolver code change only)
- [x] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made
