### PR TITLE
release: v0.1.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ## Unreleased
 
+## v0.1.25 (2026-06-05)
+
 ### Fixes
 
-* fix: retry the resolver backoff dialer on "connection refused" (not only on timeouts), avoiding a 502 on the first request after scale-from-zero when the target pod or kube-proxy route is not ready yet by `@sandrotaje`
+* fix: retry the resolver backoff dialer on "connection refused" (not only on timeouts), avoiding a 502 on the first request after scale-from-zero when the target pod or kube-proxy route is not ready yet by `@sandrotaje` in [#286](https://github.com/KubeElasti/KubeElasti/pull/286)
+
+### Other
+
+* feat: add E2E gRPC integration tests with H2C support by `@vorflux` in [#281](https://github.com/KubeElasti/KubeElasti/pull/281)
+* adopter: add buildo by `@ramantehlan` in [#288](https://github.com/KubeElasti/KubeElasti/pull/288)
+* docs: add Envoy Gateway routing support and integration docs by `@ramantehlan` in [#289](https://github.com/KubeElasti/KubeElasti/pull/289)
 
 ## v0.1.24 (2026-05-29)
 

--- a/charts/elasti/Chart.yaml
+++ b/charts/elasti/Chart.yaml
@@ -3,8 +3,8 @@ name: elasti
 description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionality when there is no traffic and automatic scale up to 1 when traffic arrives.
 icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/assets/images/logo/logo_theme_200x200.png
 type: application
-version: 0.1.24
-appVersion: "0.1.24"
+version: 0.1.25
+appVersion: "0.1.25"
 # kubeVersion: ">=1.25.0-0"
 home: https://kubeelasti.dev
 sources:

--- a/charts/elasti/README.md
+++ b/charts/elasti/README.md
@@ -36,7 +36,7 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 | `elastiController.manager.podSecurityContext`       | pod security context                                   | `{}`                         |
 | `elastiController.manager.image.registry`           | registry to use for the deployment                     | `""`                         |
 | `elastiController.manager.image.repository`         | repository to use for the deployment                   | `tfy-images/elasti-operator` |
-| `elastiController.manager.image.tag`                | tag to use for the deployment                          | `0.1.24`                     |
+| `elastiController.manager.image.tag`                | tag to use for the deployment                          | `0.1.25`                     |
 | `elastiController.manager.imagePullPolicy`          | image pull policy                                      | `IfNotPresent`               |
 | `elastiController.manager.resources`                | resources to use for the deployment                    | `{}`                         |
 | `elastiController.manager.sentry.enabled`           | whether to enable sentry                               | `false`                      |
@@ -68,7 +68,7 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 | `elastiResolver.proxy.env`                                  | environment to use for the deployment                       | `{}`                         |
 | `elastiResolver.proxy.image.registry`                       | registry to use for the deployment                          | `""`                         |
 | `elastiResolver.proxy.image.repository`                     | repository to use for the deployment                        | `tfy-images/elasti-resolver` |
-| `elastiResolver.proxy.image.tag`                            | tag to use for the deployment                               | `0.1.24`                     |
+| `elastiResolver.proxy.image.tag`                            | tag to use for the deployment                               | `0.1.25`                     |
 | `elastiResolver.proxy.imagePullPolicy`                      | image pull policy                                           | `IfNotPresent`               |
 | `elastiResolver.proxy.resources`                            | resources to use for the deployment                         | `{}`                         |
 | `elastiResolver.proxy.containerSecurityContext`             | container security context                                  | `{}`                         |

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -87,7 +87,7 @@ elastiController:
       repository: tfy-images/elasti-operator
       ## @param elastiController.manager.image.tag tag to use for the deployment
       ##
-      tag: 0.1.24
+      tag: 0.1.25
     ## @param elastiController.manager.imagePullPolicy image pull policy
     ##
     imagePullPolicy: IfNotPresent
@@ -204,7 +204,7 @@ elastiResolver:
       repository: tfy-images/elasti-resolver
       ## @param elastiResolver.proxy.image.tag tag to use for the deployment
       ##
-      tag: 0.1.24
+      tag: 0.1.25
     ## @param elastiResolver.proxy.imagePullPolicy image pull policy
     ##
     imagePullPolicy: IfNotPresent

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -10,6 +10,35 @@ entries:
           url: https://slack.cncf.io/
       artifacthub.io/operator: "true"
     apiVersion: v2
+    appVersion: 0.1.25
+    created: "2026-06-05T15:50:56.885594+05:30"
+    description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
+      functionality when there is no traffic and automatic scale up to 1 when traffic
+      arrives.
+    digest: 3ec3b7260a375fd9454350ac08929260ffb1f0c143a37d760ec7b1ed56bd61f2
+    home: https://kubeelasti.dev
+    icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/assets/images/logo/logo_theme_200x200.png
+    keywords:
+    - Scale-to-zero
+    - Operator
+    - Cloud Native
+    - Autoscaling
+    name: elasti
+    sources:
+    - https://github.com/KubeElasti/KubeElasti
+    type: application
+    urls:
+    - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.25/elasti-0.1.25.tgz
+    version: 0.1.25
+  - annotations:
+      artifacthub.io/license: MIT
+      artifacthub.io/links: |
+        - name: Source
+          url: https://github.com/KubeElasti/KubeElasti
+        - name: CNCF Slack (#kubeelasti)
+          url: https://slack.cncf.io/
+      artifacthub.io/operator: "true"
+    apiVersion: v2
     appVersion: 0.1.24
     created: "2026-05-29T11:59:20.284246971Z"
     description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
@@ -127,4 +156,4 @@ entries:
     urls:
     - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.20/elasti-0.1.20.tgz
     version: 0.1.20
-generated: "2026-05-29T11:59:20.283078518Z"
+generated: "2026-06-05T15:50:56.884726+05:30"

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -11,11 +11,11 @@ entries:
       artifacthub.io/operator: "true"
     apiVersion: v2
     appVersion: 0.1.25
-    created: "2026-06-05T15:50:56.885594+05:30"
+    created: "2026-06-05T10:21:38.169755584Z"
     description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
       functionality when there is no traffic and automatic scale up to 1 when traffic
       arrives.
-    digest: 3ec3b7260a375fd9454350ac08929260ffb1f0c143a37d760ec7b1ed56bd61f2
+    digest: 9b74b4434e0e1b845de6b70519de6d1ff406a8707266b123afef076c74ed6b54
     home: https://kubeelasti.dev
     icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/assets/images/logo/logo_theme_200x200.png
     keywords:
@@ -156,4 +156,4 @@ entries:
     urls:
     - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.20/elasti-0.1.20.tgz
     version: 0.1.20
-generated: "2026-06-05T15:50:56.884726+05:30"
+generated: "2026-06-05T10:21:38.16839971Z"


### PR DESCRIPTION
## Summary
- Bump Helm chart and image tags to `0.1.25`
- Update `CHANGELOG.md` with fixes and improvements since v0.1.24
- Refresh `docs/index.yaml` for the new chart version

## Test plan
- [ ] CI checks pass
- [ ] Merge to `main`
- [ ] Create GitHub release `v0.1.25` to trigger the release workflow


Made with [Cursor](https://cursor.com)