### PR TITLE
feat(chart): support nodeSelector, tolerations, and affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ## Unreleased
 
+### Improvements
+
+* helm: support nodeSelector, tolerations, and affinity on elastiController and elastiResolver by @mcastellini in [#292](https://github.com/KubeElasti/KubeElasti/pull/292)
+
 ## v0.1.25 (2026-06-05)
 
 ### Fixes

--- a/charts/elasti/README.md
+++ b/charts/elasti/README.md
@@ -49,6 +49,9 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 | `elastiController.podAnnotations`                   | annotations to apply to elastiController pods          | `{}`                         |
 | `elastiController.deploymentLabels`                 | labels to apply to elastiController deployment         | `{}`                         |
 | `elastiController.deploymentAnnotations`            | annotations to apply to elastiController deployment    | `{}`                         |
+| `elastiController.affinity`                         | affinity rules for pod assignment                      | `{}`                         |
+| `elastiController.nodeSelector`                     | node labels for pod assignment                         | `{}`                         |
+| `elastiController.tolerations`                      | tolerations for pod assignment                         | `[]`                         |
 | `elastiController.serviceAccount.annotations`       | annotations to use for the deployment                  | `{}`                         |
 | `elastiController.serviceAccount.labels`            | labels to use for the service account                  | `{}`                         |
 | `elastiController.metricsService`                   | metrics service to use for the deployment              | `{}`                         |
@@ -82,6 +85,9 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 | `elastiResolver.podAnnotations`                             | annotations to apply to elastiResolver pods                 | `{}`                         |
 | `elastiResolver.deploymentLabels`                           | labels to apply to elastiResolver deployment                | `{}`                         |
 | `elastiResolver.deploymentAnnotations`                      | annotations to apply to elastiResolver deployment           | `{}`                         |
+| `elastiResolver.affinity`                                   | affinity rules for pod assignment                           | `{}`                         |
+| `elastiResolver.nodeSelector`                               | node labels for pod assignment                              | `{}`                         |
+| `elastiResolver.tolerations`                                | tolerations for pod assignment                              | `[]`                         |
 | `elastiResolver.serviceAccount.annotations`                 | annotations to use for the deployment                       | `{}`                         |
 | `elastiResolver.serviceAccount.labels`                      | labels to use for the service account                       | `{}`                         |
 | `elastiResolver.autoscaling.enabled`                        | whether to enable autoscaling                               | `false`                      |

--- a/charts/elasti/templates/deployment.yaml
+++ b/charts/elasti/templates/deployment.yaml
@@ -78,6 +78,18 @@ spec:
       terminationGracePeriodSeconds: 10
       imagePullSecrets:
         {{- include "elasti.imagePullSecrets" . | nindent 8 }}
+      {{- with .Values.elastiController.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.elastiController.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.elastiController.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -170,3 +182,15 @@ spec:
       imagePullSecrets:
         {{- include "elasti.imagePullSecrets" . | nindent 8 }}
       serviceAccountName: {{ include "elasti.fullname" . }}-resolver
+      {{- with .Values.elastiResolver.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.elastiResolver.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.elastiResolver.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -143,6 +143,15 @@ elastiController:
   ## @param elastiController.deploymentAnnotations [object] annotations to apply to elastiController deployment
   ##
   deploymentAnnotations: {}
+  ## @param elastiController.affinity [object] affinity rules for pod assignment
+  ##
+  affinity: {}
+  ## @param elastiController.nodeSelector [object] node labels for pod assignment
+  ##
+  nodeSelector: {}
+  ## @param elastiController.tolerations [array] tolerations for pod assignment
+  ##
+  tolerations: []
   serviceAccount:
     ## @param elastiController.serviceAccount.annotations [object] annotations to use for the deployment
     ##
@@ -264,6 +273,15 @@ elastiResolver:
   ## @param elastiResolver.deploymentAnnotations [object] annotations to apply to elastiResolver deployment
   ##
   deploymentAnnotations: {}
+  ## @param elastiResolver.affinity [object] affinity rules for pod assignment
+  ##
+  affinity: {}
+  ## @param elastiResolver.nodeSelector [object] node labels for pod assignment
+  ##
+  nodeSelector: {}
+  ## @param elastiResolver.tolerations [array] tolerations for pod assignment
+  ##
+  tolerations: []
   serviceAccount:
     ## @param elastiResolver.serviceAccount.annotations [object] annotations to use for the deployment
     ##


### PR DESCRIPTION
## What

Adds `nodeSelector`, `tolerations`, and `affinity` fields under both `elastiController` and `elastiResolver` so the rendered Deployments can carry pod-scheduling constraints.

## Why

The chart's `deployment.yaml` currently has no pod scheduling fields in either Deployment's pod spec, which prevents:

- Pinning Elasti to a specific node pool (e.g. a dedicated control-plane / platform pool)
- Running Elasti on clusters that taint specific nodes for system workloads

This is a standard chart pattern.

## How

Each field is wrapped in `{{- with .Values.<component>.<field> }} ... {{- end }}`, so when the value is empty (the default) nothing is rendered.

Default values are `{}` / `[]`, so existing deployments render identically.

## Verification

```bash
# Default render — no scheduling fields injected
helm template test charts/elasti | grep -cE "^      (nodeSelector|tolerations|affinity):"
# 0

# With values — fields injected
cat > /tmp/values.yaml <<EOF
elastiController:
  nodeSelector:
    node-role: platform
  tolerations:
    - key: dedicated
      operator: Equal
      value: platform
      effect: NoSchedule
elastiResolver:
  nodeSelector:
    node-role: platform
EOF
helm template test charts/elasti -f /tmp/values.yaml | grep -A 3 "nodeSelector"
```

## Notes

- Chart version intentionally left unchanged per `RELEASE.md` (version bumps are handled as part of the next stable release)
- `CHANGELOG.md` entry added under `Unreleased`
- `charts/elasti/README.md` will be regenerated by the `[CI/CD] Update README metadata` workflow once this PR is opened
