### PR TITLE
fix: add grace period for CNI to converge before disabling resolver proxy during scale-from-zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ## Unreleased
 
+### Fixes
+
+* fix: add grace period for CNI to converge before disabling resolver proxy during scale-from-zero events by `@chaserhkj` in [#293](https://github.com/KubeElasti/KubeElasti/pull/293). Fixes [#280](https://github.com/KubeElasti/KubeElasti/issues/280)
+
 ### Improvements
 
 * helm: support nodeSelector, tolerations, and affinity on elastiController and elastiResolver by @mcastellini in [#292](https://github.com/KubeElasti/KubeElasti/pull/292)

--- a/pkg/messages/host.go
+++ b/pkg/messages/host.go
@@ -2,12 +2,12 @@ package messages
 
 // Host is the host details
 type Host struct {
-	IncomingHost     string
-	Namespace        string
-	SourceService    string
-	TargetService    string
-	SourceHost       string
-	TargetHost       string
-	TrafficAllowed   bool
-	DisableScheduled bool
+	IncomingHost            string
+	Namespace               string
+	SourceService           string
+	TargetService           string
+	SourceHost              string
+	TargetHost              string
+	TrafficAllowed          bool
+	TrafficDisableScheduled bool
 }

--- a/pkg/messages/host.go
+++ b/pkg/messages/host.go
@@ -2,11 +2,12 @@ package messages
 
 // Host is the host details
 type Host struct {
-	IncomingHost   string
-	Namespace      string
-	SourceService  string
-	TargetService  string
-	SourceHost     string
-	TargetHost     string
-	TrafficAllowed bool
+	IncomingHost     string
+	Namespace        string
+	SourceService    string
+	TargetService    string
+	SourceHost       string
+	TargetHost       string
+	TrafficAllowed   bool
+	DisableScheduled bool
 }

--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -36,6 +36,8 @@ type config struct {
 	// TrafficReEnableDuration is the duration for which the traffic is disabled for a host
 	// This is also duration for which we don't recheck readiness of the service
 	TrafficReEnableDuration int `split_words:"true" default:"30"`
+	// TrafficDisableGraceDuration is the delay before disabling traffic after a proxied request completes
+	TrafficDisableGraceDuration int `split_words:"true" default:"15"`
 	// OperatorRetryDuration is the duration for which we don't inform the operator
 	// about the traffic on the same host
 	OperatorRetryDuration int `split_words:"true" default:"30"`
@@ -93,7 +95,7 @@ func main() {
 	// Get components required for the handler
 	k8sUtil := k8shelper.NewOps(logger, config)
 	newOperatorRPC := operator.NewOperatorClient(logger, time.Duration(env.OperatorRetryDuration)*time.Second)
-	newHostManager := hostmanager.NewHostManager(logger, time.Duration(env.TrafficReEnableDuration)*time.Second, env.HeaderForHost)
+	newHostManager := hostmanager.NewHostManager(logger, time.Duration(env.TrafficReEnableDuration)*time.Second, time.Duration(env.TrafficDisableGraceDuration)*time.Second, env.HeaderForHost)
 	crdCache := crdcache.New(logger, newOperatorRPC, time.Duration(env.CRDCachePollIntervalMinutes)*time.Minute)
 	crdCache.StartBackground()
 	newTransport := throttler.NewProxyAutoTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)

--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -37,6 +37,7 @@ type config struct {
 	// This is also duration for which we don't recheck readiness of the service
 	TrafficReEnableDuration int `split_words:"true" default:"30"`
 	// TrafficDisableGraceDuration is the delay before disabling traffic after a proxied request completes
+	// This time is for EndpointSlice and CNI controller to converge and start to route requests directly
 	TrafficDisableGraceDuration int `split_words:"true" default:"15"`
 	// OperatorRetryDuration is the duration for which we don't inform the operator
 	// about the traffic on the same host

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -55,6 +55,7 @@ type (
 	HostManager interface {
 		GetHost(req *http.Request) (*messages.Host, error)
 		DisableTrafficForHost(service string)
+		ScheduleDisableTrafficForHost(service string)
 	}
 )
 
@@ -152,7 +153,7 @@ func (h *Handler) handleAnyRequest(w http.ResponseWriter, req *http.Request) (*m
 				hub.CaptureException(err)
 				return err
 			}
-			h.hostManager.DisableTrafficForHost(host.IncomingHost)
+			h.hostManager.ScheduleDisableTrafficForHost(host.IncomingHost)
 			return nil
 		}, func() {
 			h.operatorRPC.SendIncomingRequestInfo(host.Namespace, host.SourceService)

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -54,7 +54,6 @@ type (
 	// HostManager is to manage the hosts, and their traffic
 	HostManager interface {
 		GetHost(req *http.Request) (*messages.Host, error)
-		DisableTrafficForHost(service string)
 		ScheduleDisableTrafficForHost(service string)
 	}
 )

--- a/resolver/internal/hostmanager/hostManager.go
+++ b/resolver/internal/hostmanager/hostManager.go
@@ -21,21 +21,21 @@ import (
 // It is used to process incoming requests and cache the host details in "hosts" map
 // For further requests, the cache is used to get the host details
 type HostManager struct {
-	logger                  *zap.Logger
-	hosts                   sync.Map
-	trafficReEnableDuration time.Duration
-	headerForHost           string
+	logger                     *zap.Logger
+	hosts                      sync.Map
+	trafficReEnableDuration    time.Duration
+	trafficDisableGraceDuration time.Duration
+	headerForHost              string
 }
 
-const proxyModeDrainDelay = 30 * time.Second
-
 // NewHostManager returns a new HostManager
-func NewHostManager(logger *zap.Logger, trafficReEnableDuration time.Duration, headerForHost string) *HostManager {
+func NewHostManager(logger *zap.Logger, trafficReEnableDuration, trafficDisableGraceDuration time.Duration, headerForHost string) *HostManager {
 	return &HostManager{
-		logger:                  logger.With(zap.String("component", "hostManager")),
-		hosts:                   sync.Map{},
-		trafficReEnableDuration: trafficReEnableDuration,
-		headerForHost:           headerForHost,
+		logger:                     logger.With(zap.String("component", "hostManager")),
+		hosts:                      sync.Map{},
+		trafficReEnableDuration:    trafficReEnableDuration,
+		trafficDisableGraceDuration: trafficDisableGraceDuration,
+		headerForHost:              headerForHost,
 	}
 }
 
@@ -106,8 +106,8 @@ func (hm *HostManager) ScheduleDisableTrafficForHost(hostName string) {
 	hm.hosts.Store(hostName, h)
 	hm.logger.Debug("Scheduled delayed disable for host",
 		zap.String("hostName", logger.MaskMiddle(hostName, 4, 4)),
-		zap.Duration("delay", proxyModeDrainDelay))
-	go time.AfterFunc(proxyModeDrainDelay, func() {
+		zap.Duration("delay", hm.trafficDisableGraceDuration))
+	go time.AfterFunc(hm.trafficDisableGraceDuration, func() {
 		if host, ok := hm.hosts.Load(hostName); ok {
 			h := host.(*messages.Host)
 			h.DisableScheduled = false

--- a/resolver/internal/hostmanager/hostManager.go
+++ b/resolver/internal/hostmanager/hostManager.go
@@ -101,10 +101,10 @@ func (hm *HostManager) ScheduleDisableTrafficForHost(hostName string) {
 		return
 	}
 	h := host.(*messages.Host)
-	if h.DisableScheduled {
+	if h.TrafficDisableScheduled {
 		return
 	}
-	h.DisableScheduled = true
+	h.TrafficDisableScheduled = true
 	hm.hosts.Store(hostName, h)
 	hm.logger.Debug("Scheduled delayed disable for host",
 		zap.String("hostName", logger.MaskMiddle(hostName, 4, 4)),
@@ -112,7 +112,7 @@ func (hm *HostManager) ScheduleDisableTrafficForHost(hostName string) {
 	go time.AfterFunc(hm.trafficDisableGraceDuration, func() {
 		if host, ok := hm.hosts.Load(hostName); ok {
 			h := host.(*messages.Host)
-			h.DisableScheduled = false
+			h.TrafficDisableScheduled = false
 			hm.hosts.Store(hostName, h)
 		}
 		hm.disableTrafficForHost(hostName)

--- a/resolver/internal/hostmanager/hostManager.go
+++ b/resolver/internal/hostmanager/hostManager.go
@@ -21,21 +21,21 @@ import (
 // It is used to process incoming requests and cache the host details in "hosts" map
 // For further requests, the cache is used to get the host details
 type HostManager struct {
-	logger                     *zap.Logger
-	hosts                      sync.Map
-	trafficReEnableDuration    time.Duration
+	logger                      *zap.Logger
+	hosts                       sync.Map
+	trafficReEnableDuration     time.Duration
 	trafficDisableGraceDuration time.Duration
-	headerForHost              string
+	headerForHost               string
 }
 
 // NewHostManager returns a new HostManager
 func NewHostManager(logger *zap.Logger, trafficReEnableDuration, trafficDisableGraceDuration time.Duration, headerForHost string) *HostManager {
 	return &HostManager{
-		logger:                     logger.With(zap.String("component", "hostManager")),
-		hosts:                      sync.Map{},
-		trafficReEnableDuration:    trafficReEnableDuration,
+		logger:                      logger.With(zap.String("component", "hostManager")),
+		hosts:                       sync.Map{},
+		trafficReEnableDuration:     trafficReEnableDuration,
 		trafficDisableGraceDuration: trafficDisableGraceDuration,
-		headerForHost:              headerForHost,
+		headerForHost:               headerForHost,
 	}
 }
 
@@ -76,7 +76,7 @@ func (hm *HostManager) GetHost(req *http.Request) (*messages.Host, error) {
 }
 
 // DisableTrafficForHost disables the traffic for the host
-func (hm *HostManager) DisableTrafficForHost(hostName string) {
+func (hm *HostManager) disableTrafficForHost(hostName string) {
 	if host, ok := hm.hosts.Load(hostName); ok && host.(*messages.Host).TrafficAllowed {
 		host.(*messages.Host).TrafficAllowed = false
 		hm.hosts.Store(hostName, host)
@@ -91,8 +91,10 @@ func (hm *HostManager) DisableTrafficForHost(hostName string) {
 }
 
 // ScheduleDisableTrafficForHost schedules a delayed disable of traffic for the host.
-// The disable fires after a fixed delay, and only one timer is scheduled per host
+// The disable fires after TrafficDisableGraceDuration, and only one timer is scheduled per host
 // regardless of how many requests arrive during the delay window.
+// This allows a grace period for EndpointSlice and CNI controller to converge on route changes
+// before the resolver stops routing requests
 func (hm *HostManager) ScheduleDisableTrafficForHost(hostName string) {
 	host, ok := hm.hosts.Load(hostName)
 	if !ok {
@@ -113,7 +115,7 @@ func (hm *HostManager) ScheduleDisableTrafficForHost(hostName string) {
 			h.DisableScheduled = false
 			hm.hosts.Store(hostName, h)
 		}
-		hm.DisableTrafficForHost(hostName)
+		hm.disableTrafficForHost(hostName)
 	})
 }
 

--- a/resolver/internal/hostmanager/hostManager.go
+++ b/resolver/internal/hostmanager/hostManager.go
@@ -27,6 +27,8 @@ type HostManager struct {
 	headerForHost           string
 }
 
+const proxyModeDrainDelay = 30 * time.Second
+
 // NewHostManager returns a new HostManager
 func NewHostManager(logger *zap.Logger, trafficReEnableDuration time.Duration, headerForHost string) *HostManager {
 	return &HostManager{
@@ -86,6 +88,33 @@ func (hm *HostManager) DisableTrafficForHost(hostName string) {
 		})
 		prom.TrafficSwitchCounter.WithLabelValues(hostName, "disabled").Inc()
 	}
+}
+
+// ScheduleDisableTrafficForHost schedules a delayed disable of traffic for the host.
+// The disable fires after a fixed delay, and only one timer is scheduled per host
+// regardless of how many requests arrive during the delay window.
+func (hm *HostManager) ScheduleDisableTrafficForHost(hostName string) {
+	host, ok := hm.hosts.Load(hostName)
+	if !ok {
+		return
+	}
+	h := host.(*messages.Host)
+	if h.DisableScheduled {
+		return
+	}
+	h.DisableScheduled = true
+	hm.hosts.Store(hostName, h)
+	hm.logger.Debug("Scheduled delayed disable for host",
+		zap.String("hostName", logger.MaskMiddle(hostName, 4, 4)),
+		zap.Duration("delay", proxyModeDrainDelay))
+	go time.AfterFunc(proxyModeDrainDelay, func() {
+		if host, ok := hm.hosts.Load(hostName); ok {
+			h := host.(*messages.Host)
+			h.DisableScheduled = false
+			hm.hosts.Store(hostName, h)
+		}
+		hm.DisableTrafficForHost(hostName)
+	})
 }
 
 // enableTrafficForHost enables the traffic for the host

--- a/resolver/internal/hostmanager/hostManager_test.go
+++ b/resolver/internal/hostmanager/hostManager_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetHost(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	hm := NewHostManager(logger, 10*time.Second, "X-Envoy-Decorator-Operation")
+	hm := NewHostManager(logger, 10*time.Second, 15*time.Second, "X-Envoy-Decorator-Operation")
 
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Description
Fixes #280 

This PR adds a configurable grace period to wait for changes in `EndpointSlice` to converge with the CNI drivers during a scale-from-zero event. During the grace period, the resolver will continue routing requests for the service, since they might be still arriving before the CNI driver states are converged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

This fixes a race condition bug that is hard in nature to test, either in unit tests or integration tests.

- [x] Tested on my cluster with a git http service, which is recognized as the most likely victim in issue #280 , the issue no longer manifested for the tests that I performed. 

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
- [ ] A PR is open to update the helm chart (link)[https://github.com/KubeElasti/KubeElasti/tree/main/charts/elasti] if applicable
- [x] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made
