### PR TITLE
fix: bound generated service & endpointslice names to Kubernetes limits (#294)

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,30 +3,60 @@ package utils
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"strings"
 )
 
 const (
 	prefix                = "elasti-"
 	privateServicePostfix = "-pvt"
 	endpointSlicePostfix  = "-endpointslice-to-resolver"
+
+	// hashLength is the number of hex characters of the source name's hash
+	// appended to generated names to keep them unique.
+	hashLength = 10
+
+	// maxServiceNameLength is the maximum length of a Kubernetes Service name
+	// (an RFC 1035 label). The API server rejects longer names.
+	maxServiceNameLength = 63
+	// maxEndpointSliceNameLength is the maximum length of a Kubernetes
+	// EndpointSlice name (an RFC 1123 subdomain).
+	maxEndpointSliceNameLength = 253
 )
 
-// GetPrivateServiceName returns a private service name for a given public service name
-// This generates a hash of the public service name and appends it to the private service name
-// This way it decrease the chances of user having a same name, however, to be noted, the has will always be the same
-// if the public service name is same
+// GetPrivateServiceName returns a private service name for a given public service name.
+// It generates a hash of the public service name and appends it to the private service name.
+// This decreases the chance of a naming collision; note the hash is deterministic, so the
+// same public service name always yields the same private service name.
+// The public service name is truncated as needed so the result never exceeds the Kubernetes
+// 63-character Service name limit, while the hash (always derived from the full name) preserves
+// uniqueness even when the name is truncated.
 func GetPrivateServiceName(publicSVCName string) string {
-	hash := sha256.New()
-	hash.Write([]byte(publicSVCName))
-	hashed := hex.EncodeToString(hash.Sum(nil))
-	pvtName := prefix + publicSVCName + privateServicePostfix + "-" + hashed[:10]
-	return pvtName
+	return buildName(publicSVCName, privateServicePostfix, maxServiceNameLength)
 }
 
-// GetEndpointSliceToResolverName returns an endpoint slice name for a given service name
+// GetEndpointSliceToResolverName returns an endpoint slice name for a given service name.
+// As with GetPrivateServiceName, the source name is truncated so the result stays within the
+// Kubernetes 253-character EndpointSlice name limit while remaining deterministic and unique.
 func GetEndpointSliceToResolverName(serviceName string) string {
+	return buildName(serviceName, endpointSlicePostfix, maxEndpointSliceNameLength)
+}
+
+// buildName constructs a deterministic, length-bounded name of the form
+// "<prefix><name><postfix>-<hash>". The hash is always computed from the full, untruncated
+// name so uniqueness is preserved even when name is shortened to fit maxLength.
+func buildName(name, postfix string, maxLength int) string {
 	hash := sha256.New()
-	hash.Write([]byte(serviceName))
-	hashed := hex.EncodeToString(hash.Sum(nil))
-	return prefix + serviceName + endpointSlicePostfix + "-" + hashed[:10]
+	hash.Write([]byte(name))
+	hashed := hex.EncodeToString(hash.Sum(nil))[:hashLength]
+
+	// Fixed overhead is everything except the (possibly truncated) source name:
+	// prefix + postfix + "-" + hash.
+	overhead := len(prefix) + len(postfix) + 1 + hashLength
+	maxNameLength := max(maxLength-overhead, 0)
+	if len(name) > maxNameLength {
+		name = name[:maxNameLength]
+		// Avoid leaving a trailing hyphen so the segment before the postfix stays tidy.
+		name = strings.TrimRight(name, "-")
+	}
+	return prefix + name + postfix + "-" + hashed
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetPrivateServiceName(t *testing.T) {
+	t.Run("stays within the 63-character Service limit for long names", func(t *testing.T) {
+		long := "my-very-long-application-backend-service-v2-with-extra-suffix"
+		got := GetPrivateServiceName(long)
+		if len(got) > maxServiceNameLength {
+			t.Errorf("name %q has length %d, exceeds limit %d", got, len(got), maxServiceNameLength)
+		}
+		if !strings.HasPrefix(got, prefix) {
+			t.Errorf("name %q does not start with prefix %q", got, prefix)
+		}
+	})
+
+	t.Run("is deterministic", func(t *testing.T) {
+		name := "my-very-long-application-backend-service-v2-with-extra-suffix"
+		first, second := GetPrivateServiceName(name), GetPrivateServiceName(name)
+		if first != second {
+			t.Errorf("GetPrivateServiceName is not deterministic for %q: %q != %q", name, first, second)
+		}
+	})
+
+	t.Run("distinguishes names sharing a truncated prefix via the hash", func(t *testing.T) {
+		a := "my-very-long-application-backend-service-aaaaaaaaaaaaaaaaaaaa"
+		b := "my-very-long-application-backend-service-bbbbbbbbbbbbbbbbbbbb"
+		if GetPrivateServiceName(a) == GetPrivateServiceName(b) {
+			t.Errorf("expected distinct names for %q and %q", a, b)
+		}
+	})
+
+	t.Run("preserves short names unchanged", func(t *testing.T) {
+		got := GetPrivateServiceName("svc")
+		if got != prefix+"svc"+privateServicePostfix+"-"+got[len(got)-hashLength:] {
+			t.Errorf("unexpected name for short input: %q", got)
+		}
+	})
+
+	t.Run("does not leave a trailing hyphen before the postfix", func(t *testing.T) {
+		// 41 chars then a hyphen at the truncation boundary; ensure no "--pvt".
+		name := strings.Repeat("a", maxServiceNameLength) + "-" + strings.Repeat("b", 10)
+		got := GetPrivateServiceName(name)
+		if strings.Contains(got, "--"+strings.TrimPrefix(privateServicePostfix, "-")) {
+			t.Errorf("name %q contains a doubled hyphen before postfix", got)
+		}
+		if len(got) > maxServiceNameLength {
+			t.Errorf("name %q exceeds limit %d", got, maxServiceNameLength)
+		}
+	})
+}
+
+func TestGetEndpointSliceToResolverName(t *testing.T) {
+	t.Run("stays within the 253-character EndpointSlice limit", func(t *testing.T) {
+		long := strings.Repeat("a", 300)
+		got := GetEndpointSliceToResolverName(long)
+		if len(got) > maxEndpointSliceNameLength {
+			t.Errorf("name %q has length %d, exceeds limit %d", got, len(got), maxEndpointSliceNameLength)
+		}
+	})
+
+	t.Run("is deterministic", func(t *testing.T) {
+		name := strings.Repeat("a", 300)
+		first, second := GetEndpointSliceToResolverName(name), GetEndpointSliceToResolverName(name)
+		if first != second {
+			t.Errorf("GetEndpointSliceToResolverName is not deterministic: %q != %q", first, second)
+		}
+	})
+}


### PR DESCRIPTION
## What

Fixes #294.

`GetPrivateServiceName` generated names of the form `elasti-<name>-pvt-<10-char-hash>`, which carries 22 characters of fixed overhead. Any source Service whose name exceeds **41 characters** produced a private Service name longer than Kubernetes' **63-character** Service name limit, and the API server rejected the `Service` with `must be no more than 63 characters`. The reconcile loop then failed and the target was never put into proxy mode.

```
Service "elasti-service_name-pvt-9e59e10fd0" is invalid: metadata.name: Invalid value: ...: must be no more than 63 characters
```

## How

Extracted a shared `buildName` helper used by both naming functions:

- **`GetPrivateServiceName`** — bounded to the 63-char Service limit.
- **`GetEndpointSliceToResolverName`** — bounded to the 253-char EndpointSlice limit.

`buildName`:
- Always computes the SHA-256 hash from the **full, untruncated** source name, so uniqueness is preserved even when the name is shortened.
- Truncates only the source-name portion so the total length never exceeds the relevant limit.
- Trims any trailing hyphen left by truncation to avoid a doubled `--pvt` hyphen.

The functions remain fully deterministic — important because the resolver independently recomputes the private-service name to route requests.

## Tests

Added `pkg/utils/utils_test.go` covering:
- Length bounds for both functions (long names stay within 63 / 253).
- Determinism.
- Two long names sharing a truncated prefix still get distinct names via the hash.
- Short names are unchanged.
- No doubled-hyphen at the truncation boundary.

`operator` and `resolver` build cleanly against the change.

## Out of scope

The issue's optional enhancement — making the `elasti-` / `-pvt` / `-endpointslice-to-resolver` affixes configurable via the Helm `values.yaml` — is intentionally left for a follow-up. It touches CRD/controller/chart plumbing and would change generated names for existing installs (a migration concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)