### PR TITLE
feat: generate and publish SBOMs for images and chart on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,8 @@ jobs:
       dockerfile_path: "operator/Dockerfile"
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
       artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
+      enable_sbom: true
+      sbom_artifact_name: "sbom-elasti-operator"
     secrets:
       artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
       artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
@@ -83,6 +85,8 @@ jobs:
       dockerfile_path: "resolver/Dockerfile"
       artifactory_registry_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_REGISTRY_URL }}
       artifactory_repository_url: ${{ vars.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_REPOSITORY }}
+      enable_sbom: true
+      sbom_artifact_name: "sbom-elasti-resolver"
     secrets:
       artifactory_username: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_USERNAME }}
       artifactory_password: ${{ secrets.TRUEFOUNDRY_ARTIFACTORY_PUBLIC_PASSWORD }}
@@ -120,10 +124,42 @@ jobs:
           helm push $CHART_NAME-$CHART_VERSION.tgz oci://${{ env.HELM_CHART_REPOSITORY}}
           echo "Successfully pushed chart: $CHART_NAME"
 
-      - name: Upload Helm chart to release
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0
+        id: syft
+
+      - name: Generate Helm chart SBOM
+        env:
+          SYFT: ${{ steps.syft.outputs.cmd }}
+          CHART_NAME: ${{ needs.read-chart-values.outputs.chart_name }}
+          CHART_VERSION: ${{ needs.read-chart-values.outputs.chart_version }}
+        run: |
+          set -euo pipefail
+          SBOM_FILE="charts/${CHART_NAME}-${CHART_VERSION}.sbom.spdx.json"
+          echo "Generating SBOM for chart ${CHART_NAME}-${CHART_VERSION}"
+          "$SYFT" scan "dir:charts/elasti" -o spdx-json="${SBOM_FILE}"
+          echo "Generated SBOM: ${SBOM_FILE}"
+
+      - name: Download operator image SBOM
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-operator.outputs.sbom_artifact_name }}
+          path: image-sboms
+
+      - name: Download resolver image SBOM
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-resolver.outputs.sbom_artifact_name }}
+          path: image-sboms
+
+      - name: Upload Helm chart and SBOMs to release
         uses: softprops/action-gh-release@v2
         with:
-            files: "charts/${{ needs.read-chart-values.outputs.chart_name }}-${{ needs.read-chart-values.outputs.chart_version }}.tgz"
+            files: |
+              charts/${{ needs.read-chart-values.outputs.chart_name }}-${{ needs.read-chart-values.outputs.chart_version }}.tgz
+              charts/${{ needs.read-chart-values.outputs.chart_name }}-${{ needs.read-chart-values.outputs.chart_version }}.sbom.spdx.json
+              image-sboms/${{ needs.build-operator.outputs.sbom_file_name }}
+              image-sboms/${{ needs.build-resolver.outputs.sbom_file_name }}
             tag_name: "${{ github.ref_name }}"
             fail_on_unmatched_files: true
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - v*
+    # TODO: temporary — for testing SBOM generation on branch pushes. Remove before merge.
+    branches:
+      - rt/sbom
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - v*
-    # TODO: temporary — for testing SBOM generation on branch pushes. Remove before merge.
-    branches:
-      - rt/sbom
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Generate SBOMs during the release and attach them to the GitHub Release, for OpenSSF compliance. Covers both the container images and the Helm chart.

Depends on `truefoundry/github-workflows-public#25`, which updates the reusable `build.yml` to generate an SPDX SBOM for the pushed image and upload it as a workflow artifact (via the `enable_sbom` / `sbom_artifact_name` inputs and `sbom_artifact_name` / `sbom_file_name` outputs). This PR should be merged after that change is deployed.

## Changes

- **Operator & resolver images**: pass `enable_sbom: true` with a distinct `sbom_artifact_name` per image (`upload-artifact@v4` rejects duplicate artifact names within a run). The reusable workflow scans each pushed image by digest with Syft and uploads the SPDX SBOM as a workflow artifact.
- **Helm chart**: install Syft in the `release` job and generate an SPDX SBOM from the chart directory (`dir:charts/elasti`, which includes the pulled subchart dependencies).
- **Release**: download both image SBOM artifacts and attach the chart, chart SBOM, and both image SBOMs to the GitHub Release.

## Resulting release assets

```
elasti-<ver>.tgz
elasti-<ver>.sbom.spdx.json          # chart
elasti-operator-<tag>.spdx.json      # operator image
elasti-resolver-<tag>.spdx.json      # resolver image
```
