### PR TITLE
[Feat] [PR 1/3] Add opt-in namespace-scoped mode

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -45,6 +45,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -142,8 +143,22 @@ func mainWithError() error {
 		TLSOpts: tlsOpts,
 	})
 
+	// Determine the namespaces to confine KubeElasti to. An empty result keeps the default
+	// cluster-scoped behavior. When scoped, the operator's and resolver's own namespaces are
+	// always folded in so leader-election leases and the resolver's EndpointSlices stay reachable.
+	watch := config.GetWatchNamespaces()
+	if len(watch) == 0 && watchNamespace != metav1.NamespaceAll {
+		// Backward compatibility with the legacy single-namespace --watch-namespace flag.
+		watch = []string{watchNamespace}
+	}
+	watchNamespaces := effectiveWatchNamespaces(watch, config.GetOperatorConfig().Namespace, config.GetResolverConfig().Namespace)
+	if len(watchNamespaces) > 0 {
+		setupLog.Info("running in namespace-scoped mode", "namespaces", watchNamespaces)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
+		Cache:  buildCacheOptions(watchNamespaces),
 		Metrics: metricsserver.Options{
 			BindAddress:   metricsAddr,
 			SecureServing: secureMetrics,
@@ -169,7 +184,7 @@ func mainWithError() error {
 	defer informerManager.Stop()
 
 	// Initiate and start the shared scaleHandler
-	scaleHandler := scaling.NewScaleHandler(zapLogger, mgr.GetConfig(), watchNamespace, mgr.GetEventRecorderFor("elasti-operator"))
+	scaleHandler := scaling.NewScaleHandler(zapLogger, mgr.GetConfig(), watchNamespaces, mgr.GetEventRecorderFor("elasti-operator"))
 
 	// Set up the ElastiService controller
 	reconciler := &controller.ElastiServiceReconciler{
@@ -180,7 +195,7 @@ func mainWithError() error {
 		ScaleHandler:    scaleHandler,
 	}
 
-	if err = reconciler.SetupWithManager(mgr, watchNamespace); err != nil {
+	if err = reconciler.SetupWithManager(mgr, watchNamespaces); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ElastiService")
 		sentry.CaptureException(err)
 		return fmt.Errorf("main: %w", err)
@@ -237,7 +252,7 @@ func mainWithError() error {
 		return fmt.Errorf("failed to sync cache")
 	}
 
-	if err = reconciler.Initialize(context.Background(), watchNamespace); err != nil {
+	if err = reconciler.Initialize(context.Background(), watchNamespaces); err != nil {
 		setupLog.Error(err, "unable to initialize controller")
 		return fmt.Errorf("main: %w", err)
 	}
@@ -248,6 +263,49 @@ func mainWithError() error {
 	}
 
 	return nil
+}
+
+// effectiveWatchNamespaces returns the de-duplicated set of namespaces to confine the manager
+// cache and clients to. An empty watch slice means cluster scope (returns nil). When scoped, the
+// alwaysInclude namespaces (operator + resolver) are folded in — this is a correctness invariant,
+// not a nicety, since the resolver's own EndpointSlices must remain reachable.
+func effectiveWatchNamespaces(watch []string, alwaysInclude ...string) []string {
+	if len(watch) == 0 {
+		return nil
+	}
+
+	all := make([]string, 0, len(watch)+len(alwaysInclude))
+	all = append(all, watch...)
+	all = append(all, alwaysInclude...)
+
+	seen := make(map[string]struct{}, len(all))
+	out := make([]string, 0, len(all))
+	for _, ns := range all {
+		if ns == "" {
+			continue
+		}
+		if _, ok := seen[ns]; ok {
+			continue
+		}
+		seen[ns] = struct{}{}
+		out = append(out, ns)
+	}
+	return out
+}
+
+// buildCacheOptions restricts the manager cache to the given namespaces. When the list is empty it
+// returns the zero-value cache.Options — byte-for-byte identical to the default cluster-scoped
+// behavior.
+func buildCacheOptions(watchNamespaces []string) cache.Options {
+	if len(watchNamespaces) == 0 {
+		return cache.Options{}
+	}
+
+	defaultNamespaces := make(map[string]cache.Config, len(watchNamespaces))
+	for _, ns := range watchNamespaces {
+		defaultNamespaces[ns] = cache.Config{}
+	}
+	return cache.Options{DefaultNamespaces: defaultNamespaces}
 }
 
 func _(mgr ctrl.Manager) healthz.Checker {

--- a/operator/cmd/main_test.go
+++ b/operator/cmd/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestEffectiveWatchNamespaces(t *testing.T) {
+	tests := []struct {
+		name          string
+		watch         []string
+		alwaysInclude []string
+		want          []string // order-insensitive
+	}{
+		{
+			name:          "empty watch set is cluster scope",
+			watch:         nil,
+			alwaysInclude: []string{"elasti", "elasti"},
+			want:          nil,
+		},
+		{
+			name:          "folds in operator and resolver namespaces",
+			watch:         []string{"team-a"},
+			alwaysInclude: []string{"elasti", "elasti"},
+			want:          []string{"team-a", "elasti"},
+		},
+		{
+			name:          "de-duplicates and drops empties",
+			watch:         []string{"team-a", "team-b", "team-a", ""},
+			alwaysInclude: []string{"team-b", "elasti"},
+			want:          []string{"team-a", "team-b", "elasti"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectiveWatchNamespaces(tt.watch, tt.alwaysInclude...)
+			if !equalAsSets(got, tt.want) {
+				t.Errorf("effectiveWatchNamespaces(%#v, %#v) = %#v, want set %#v", tt.watch, tt.alwaysInclude, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildCacheOptions(t *testing.T) {
+	t.Run("empty is zero-value (cluster scope, byte-identical default)", func(t *testing.T) {
+		opts := buildCacheOptions(nil)
+		if opts.DefaultNamespaces != nil {
+			t.Errorf("expected nil DefaultNamespaces for cluster scope, got %#v", opts.DefaultNamespaces)
+		}
+	})
+
+	t.Run("non-empty scopes to exactly the given namespaces", func(t *testing.T) {
+		in := []string{"team-a", "team-b", "elasti"}
+		opts := buildCacheOptions(in)
+		if len(opts.DefaultNamespaces) != len(in) {
+			t.Fatalf("expected %d namespaces, got %d: %#v", len(in), len(opts.DefaultNamespaces), opts.DefaultNamespaces)
+		}
+		for _, ns := range in {
+			if _, ok := opts.DefaultNamespaces[ns]; !ok {
+				t.Errorf("expected namespace %q in DefaultNamespaces, got %#v", ns, opts.DefaultNamespaces)
+			}
+		}
+	})
+}
+
+func equalAsSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string{}, a...)
+	bc := append([]string{}, b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/operator/internal/controller/elastiservice_controller.go
+++ b/operator/internal/controller/elastiservice_controller.go
@@ -23,7 +23,6 @@ import (
 	"truefoundry/elasti/operator/api/v1alpha1"
 
 	"go.uber.org/zap"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type (
@@ -116,7 +115,7 @@ func (r *ElastiServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	return res, nil
 }
 
-func (r *ElastiServiceReconciler) SetupWithManager(mgr ctrl.Manager, watchNamespace string) error {
+func (r *ElastiServiceReconciler) SetupWithManager(mgr ctrl.Manager, watchNamespaces []string) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.ElastiService{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(obj client.Object) bool {
@@ -124,10 +123,7 @@ func (r *ElastiServiceReconciler) SetupWithManager(mgr ctrl.Manager, watchNamesp
 			if !ok {
 				return false
 			}
-			if watchNamespace == metav1.NamespaceAll || es.Namespace == watchNamespace {
-				return true
-			}
-			return false
+			return namespaceInScope(watchNamespaces, es.Namespace)
 		})).
 		Complete(r)
 	if err != nil {
@@ -136,13 +132,27 @@ func (r *ElastiServiceReconciler) SetupWithManager(mgr ctrl.Manager, watchNamesp
 	return nil
 }
 
+// namespaceInScope reports whether the given namespace is within the configured watch set.
+// An empty watch set means cluster scope (every namespace is in scope).
+func namespaceInScope(watchNamespaces []string, namespace string) bool {
+	if len(watchNamespaces) == 0 {
+		return true
+	}
+	for _, ns := range watchNamespaces {
+		if ns == namespace {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *ElastiServiceReconciler) getMutexForReconcile(key string) *sync.Mutex {
 	l, _ := r.ReconcileLocks.LoadOrStore(key, &sync.Mutex{})
 	return l.(*sync.Mutex)
 }
 
-func (r *ElastiServiceReconciler) Initialize(ctx context.Context, watchNamespace string) error {
-	if err := r.reconcileExistingCRDs(ctx, watchNamespace); err != nil {
+func (r *ElastiServiceReconciler) Initialize(ctx context.Context, watchNamespaces []string) error {
+	if err := r.reconcileExistingCRDs(ctx, watchNamespaces); err != nil {
 		return fmt.Errorf("failed to reconcile existing CRDs: %w", err)
 	}
 	if err := r.InformerManager.InitializeResolverInformer(r.getResolverChangeHandler(ctx)); err != nil {
@@ -152,14 +162,20 @@ func (r *ElastiServiceReconciler) Initialize(ctx context.Context, watchNamespace
 	return nil
 }
 
-func (r *ElastiServiceReconciler) reconcileExistingCRDs(ctx context.Context, watchNamespace string) error {
+func (r *ElastiServiceReconciler) reconcileExistingCRDs(ctx context.Context, watchNamespaces []string) error {
 	crdList := &v1alpha1.ElastiServiceList{}
-	if err := r.List(ctx, crdList, client.InNamespace(watchNamespace)); err != nil {
+	// A bare List is served by the manager cache: it returns every ElastiService in cluster mode
+	// (empty watch set) and exactly the union of watched namespaces in namespace-scoped mode.
+	if err := r.List(ctx, crdList); err != nil {
 		return fmt.Errorf("failed to list ElastiServices: %w", err)
 	}
 	count := 0
 
 	for _, es := range crdList.Items {
+		// Defense-in-depth: skip anything outside the configured watch set (no-op in cluster mode).
+		if !namespaceInScope(watchNamespaces, es.Namespace) {
+			continue
+		}
 		// Skip if being deleted
 		if !es.DeletionTimestamp.IsZero() {
 			r.Logger.Debug("Skipping ElastiService because it is being deleted", zap.String("name", es.Name), zap.String("namespace", es.Namespace))

--- a/operator/internal/controller/opsEndpointslices.go
+++ b/operator/internal/controller/opsEndpointslices.go
@@ -18,9 +18,15 @@ import (
 
 func (r *ElastiServiceReconciler) getIPsForResolver(ctx context.Context) ([]string, error) {
 	resolverSlices := &networkingv1.EndpointSliceList{}
-	if err := r.List(ctx, resolverSlices, client.MatchingLabels{
-		"kubernetes.io/service-name": config.GetResolverConfig().ServiceName,
-	}); err != nil {
+	listOpts := []client.ListOption{
+		client.MatchingLabels{"kubernetes.io/service-name": config.GetResolverConfig().ServiceName},
+	}
+	// In namespace-scoped mode, confine the list to the resolver's own namespace (the release
+	// namespace, always in the watch set). In cluster mode the list stays cluster-wide (unchanged).
+	if len(config.GetWatchNamespaces()) > 0 {
+		listOpts = append(listOpts, client.InNamespace(config.GetResolverConfig().Namespace))
+	}
+	if err := r.List(ctx, resolverSlices, listOpts...); err != nil {
 		r.Logger.Error("Failed to get Resolver endpoint slices", zap.Error(err))
 		return nil, fmt.Errorf("getIPsForResolver: %w", err)
 	}

--- a/operator/internal/controller/scope_test.go
+++ b/operator/internal/controller/scope_test.go
@@ -1,0 +1,25 @@
+package controller
+
+import "testing"
+
+func TestNamespaceInScope(t *testing.T) {
+	tests := []struct {
+		name            string
+		watchNamespaces []string
+		namespace       string
+		want            bool
+	}{
+		{name: "cluster scope allows any namespace", watchNamespaces: nil, namespace: "anything", want: true},
+		{name: "watched namespace is in scope", watchNamespaces: []string{"team-a", "team-b"}, namespace: "team-a", want: true},
+		{name: "unwatched namespace is ignored", watchNamespaces: []string{"team-a", "team-b"}, namespace: "team-c", want: false},
+		{name: "release namespace in scope", watchNamespaces: []string{"team-a", "elasti"}, namespace: "elasti", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := namespaceInScope(tt.watchNamespaces, tt.namespace); got != tt.want {
+				t.Errorf("namespaceInScope(%#v, %q) = %v, want %v", tt.watchNamespaces, tt.namespace, got, tt.want)
+			}
+		})
+	}
+}

--- a/operator/internal/controller/suite_test.go
+++ b/operator/internal/controller/suite_test.go
@@ -124,7 +124,7 @@ var _ = BeforeSuite(func() {
 		InformerStartLocks: sync.Map{},
 		ReconcileLocks:     sync.Map{},
 	}
-	Expect(controllerReconciler.SetupWithManager(mgr, metav1.NamespaceAll)).To(Succeed())
+	Expect(controllerReconciler.SetupWithManager(mgr, nil)).To(Succeed())
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -17,6 +18,9 @@ const (
 	EnvOperatorServiceName     = "ELASTI_OPERATOR_SERVICE_NAME"
 	EnvOperatorPort            = "ELASTI_OPERATOR_PORT"
 	EnvKubernetesClusterDomain = "KUBERNETES_CLUSTER_DOMAIN"
+	// EnvWatchNamespaces is an optional, comma-separated list of namespaces to confine
+	// KubeElasti to. When unset or empty, KubeElasti runs cluster-scoped (the default).
+	EnvWatchNamespaces = "WATCH_NAMESPACES"
 )
 
 // Config holds component namespace/name/service and listen port sourced from env.
@@ -61,6 +65,23 @@ func GetOperatorConfig() Config {
 		ServiceName:    getEnvStringOrPanic(EnvOperatorServiceName),
 		Port:           getEnvPortOrPanic(EnvOperatorPort),
 	}
+}
+
+// GetWatchNamespaces returns the list of namespaces KubeElasti is confined to, parsed from the
+// WATCH_NAMESPACES env var (comma-separated). An empty result means cluster scope (the default).
+func GetWatchNamespaces() []string {
+	raw := os.Getenv(EnvWatchNamespaces)
+	if raw == "" {
+		return nil
+	}
+
+	namespaces := make([]string, 0)
+	for _, ns := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(ns); trimmed != "" {
+			namespaces = append(namespaces, trimmed)
+		}
+	}
+	return namespaces
 }
 
 // getEnvStringOrPanic returns the env value or panics if unset.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetWatchNamespaces(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		set  bool
+		want []string
+	}{
+		{name: "unset returns nil (cluster scope)", set: false, want: nil},
+		{name: "empty string returns nil (cluster scope)", env: "", set: true, want: nil},
+		{name: "single namespace", env: "team-a", set: true, want: []string{"team-a"}},
+		{name: "multiple namespaces", env: "team-a,team-b", set: true, want: []string{"team-a", "team-b"}},
+		{name: "trims whitespace", env: " team-a , team-b ", set: true, want: []string{"team-a", "team-b"}},
+		{name: "drops empty entries", env: "team-a,,team-b,", set: true, want: []string{"team-a", "team-b"}},
+		{name: "only separators returns empty", env: " , , ", set: true, want: []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv(EnvWatchNamespaces, tt.env)
+			} else {
+				// t.Setenv guarantees restoration; unset explicitly for the "unset" case.
+				t.Setenv(EnvWatchNamespaces, "")
+			}
+
+			got := GetWatchNamespaces()
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetWatchNamespaces() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/scaling/namespaces_test.go
+++ b/pkg/scaling/namespaces_test.go
@@ -1,0 +1,49 @@
+package scaling
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestListNamespaces(t *testing.T) {
+	tests := []struct {
+		name            string
+		watchNamespaces []string
+		want            []string
+	}{
+		{
+			name:            "empty watch set queries all namespaces once (cluster scope, unchanged default)",
+			watchNamespaces: nil,
+			want:            []string{metav1.NamespaceAll},
+		},
+		{
+			name:            "single namespace is queried scoped, never all-namespace",
+			watchNamespaces: []string{"team-a"},
+			want:            []string{"team-a"},
+		},
+		{
+			name:            "each configured namespace is queried once",
+			watchNamespaces: []string{"team-a", "team-b", "elasti"},
+			want:            []string{"team-a", "team-b", "elasti"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := listNamespaces(tt.watchNamespaces)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("listNamespaces(%#v) = %#v, want %#v", tt.watchNamespaces, got, tt.want)
+			}
+			// In scoped mode the all-namespaces sentinel must never appear.
+			if len(tt.watchNamespaces) > 0 {
+				for _, ns := range got {
+					if ns == metav1.NamespaceAll {
+						t.Errorf("scoped mode issued an all-namespace query for %#v", tt.watchNamespaces)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -2,6 +2,7 @@ package scaling
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -55,8 +56,8 @@ type ScaleHandler struct {
 	scaleClient scale.ScalesGetter
 	restMapper  *restmapper.DeferredDiscoveryRESTMapper
 
-	logger         *zap.Logger
-	watchNamespace string
+	logger          *zap.Logger
+	watchNamespaces []string
 }
 
 // getMutexForScale returns a mutex for scaling based on the input key
@@ -66,7 +67,7 @@ func (h *ScaleHandler) getMutexForScale(key string) *sync.Mutex {
 }
 
 // NewScaleHandler creates a new instance of the ScaleHandler
-func NewScaleHandler(logger *zap.Logger, config *rest.Config, watchNamespace string, eventRecorder record.EventRecorder) *ScaleHandler {
+func NewScaleHandler(logger *zap.Logger, config *rest.Config, watchNamespaces []string, eventRecorder record.EventRecorder) *ScaleHandler {
 	kClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		logger.Fatal("Error connecting with kubernetes", zap.Error(err))
@@ -88,13 +89,13 @@ func NewScaleHandler(logger *zap.Logger, config *rest.Config, watchNamespace str
 	}
 
 	return &ScaleHandler{
-		logger:         logger.Named("ScaleHandler"),
-		kClient:        kClient,
-		kDynamicClient: kDynamicClient,
-		scaleClient:    scaleClient,
-		restMapper:     restMapper,
-		watchNamespace: watchNamespace,
-		EventRecorder:  eventRecorder,
+		logger:          logger.Named("ScaleHandler"),
+		kClient:         kClient,
+		kDynamicClient:  kDynamicClient,
+		scaleClient:     scaleClient,
+		restMapper:      restMapper,
+		watchNamespaces: watchNamespaces,
+		EventRecorder:   eventRecorder,
 	}
 }
 
@@ -128,44 +129,63 @@ func (h *ScaleHandler) StartScaleDownWatcher(ctx context.Context) {
 	}()
 }
 
+// listNamespaces returns the namespaces to query for ElastiServices. An empty watch set means
+// cluster scope: a single all-namespaces query (metav1.NamespaceAll), identical to the default
+// behavior. A non-empty set yields one scoped query per namespace and never an all-namespace list.
+func listNamespaces(watchNamespaces []string) []string {
+	if len(watchNamespaces) == 0 {
+		return []string{metav1.NamespaceAll}
+	}
+	return watchNamespaces
+}
+
 func (h *ScaleHandler) checkAndScale(ctx context.Context) error {
-	elastiServiceList, err := h.kDynamicClient.Resource(values.ElastiServiceGVR).Namespace(h.watchNamespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to list ElastiServices: %w", err)
-	}
-
-	for _, item := range elastiServiceList.Items {
-		es := &v1alpha1.ElastiService{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, es); err != nil {
-			h.logger.Error("failed to convert unstructured to ElastiService", zap.Error(err))
-			continue
-		}
-		cooldownPeriod := resolveCooldownPeriod(es)
-
-		scaleDirection, err := h.calculateScaleDirection(ctx, cooldownPeriod, es)
+	// This client is not cache-backed, so namespace scoping must be enforced here.
+	var listErrs []error
+	for _, ns := range listNamespaces(h.watchNamespaces) {
+		elastiServiceList, err := h.kDynamicClient.Resource(values.ElastiServiceGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			h.logger.Error("failed to calculate scale direction", zap.String("service", es.Spec.Service), zap.String("namespace", es.Namespace), zap.Error(err))
-			continue
-		} else if scaleDirection == NoScale {
+			// Continue on partial failure so one bad namespace can't stall scaling for the rest.
+			listErrs = append(listErrs, fmt.Errorf("namespace %q: %w", ns, err))
 			continue
 		}
 
-		switch scaleDirection {
-		case ScaleDown:
-			err := h.handleScaleToZero(ctx, es)
-			if err != nil {
-				h.logger.Error("failed to scale target to zero", zap.String("service", es.Spec.Service), zap.String("namespace", es.Namespace), zap.Error(err))
+		for _, item := range elastiServiceList.Items {
+			es := &v1alpha1.ElastiService{}
+			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, es); err != nil {
+				h.logger.Error("failed to convert unstructured to ElastiService", zap.Error(err))
 				continue
 			}
-		case ScaleUp:
-			err := h.handleScaleFromZero(ctx, es)
+			cooldownPeriod := resolveCooldownPeriod(es)
+
+			scaleDirection, err := h.calculateScaleDirection(ctx, cooldownPeriod, es)
 			if err != nil {
-				h.logger.Error("failed to scale target from zero", zap.String("service", es.Spec.Service), zap.String("namespace", es.Namespace), zap.Error(err))
+				h.logger.Error("failed to calculate scale direction", zap.String("service", es.Spec.Service), zap.String("namespace", es.Namespace), zap.Error(err))
 				continue
+			} else if scaleDirection == NoScale {
+				continue
+			}
+
+			switch scaleDirection {
+			case ScaleDown:
+				err := h.handleScaleToZero(ctx, es)
+				if err != nil {
+					h.logger.Error("failed to scale target to zero", zap.String("service", es.Spec.Service), zap.String("namespace", es.Namespace), zap.Error(err))
+					continue
+				}
+			case ScaleUp:
+				err := h.handleScaleFromZero(ctx, es)
+				if err != nil {
+					h.logger.Error("failed to scale target from zero", zap.String("service", es.Spec.Service), zap.String("namespace", es.Namespace), zap.Error(err))
+					continue
+				}
 			}
 		}
 	}
 
+	if len(listErrs) > 0 {
+		return fmt.Errorf("failed to list ElastiServices: %w", errors.Join(listErrs...))
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Problem

- KubeElasti ships only cluster-scoped RBAC (`ClusterRole` + `ClusterRoleBinding`) for operator and resolver.
- Clusters that forbid cluster-wide RBAC (multi-tenant, regulated, namespace-confined teams) cannot install it.

## Change

- New env var `WATCH_NAMESPACES` (comma-separated) selects the mode.
- unset/empty: cluster-scoped (today's default, unchanged).
- non-empty: namespace-scoped, confined to that list plus operator/resolver own namespace.

```mermaid
flowchart TD
    A[Operator start] --> B{WATCH_NAMESPACES}
    B -->|empty| C[Zero-value cache.Options]
    C --> C2[Informers in ALL namespaces]
    C2 --> C3[Predicate admits every namespace]
    C3 --> C4[Scale handler: single all-namespaces list]
    B -->|"team-a,team-b"| D[Cache.DefaultNamespaces set]
    D --> D1[Fold in operator + resolver namespace, de-dupe]
    D1 --> D2[Informers only in listed namespaces]
    D2 --> D3[Predicate namespaceInScope check]
    D3 --> D4[Scale handler: loop per namespace]
    D4 --> D5[No cluster-wide list/watch]
```

## Files

| Area | File | Change |
|------|------|--------|
| Config | `pkg/config/config.go` | `WATCH_NAMESPACES` env + `GetWatchNamespaces()` parser (comma-split, trim, drop empties). |
| Operator cache | `operator/cmd/main.go` | `buildCacheOptions()` sets `Cache.DefaultNamespaces` when scoped (core fix); `effectiveWatchNamespaces()` folds in own namespaces and de-dupes. |
| Controller | `operator/internal/controller/elastiservice_controller.go` | Predicate and existing-CR reconcile use `namespaceInScope()`. |
| Resolver-slice lookup | `operator/internal/controller/opsEndpointslices.go` | `EndpointSlice` list confined to resolver namespace when scoped. |
| Scale handler | `pkg/scaling/scale_handler.go` | Scale-down poller lists per configured namespace, continues on partial failure. |
| Tests | `*_test.go` (4 new) | Parser, cache-options invariant, per-namespace scaling, out-of-scope filtering. |

## Why the cache is the linchpin

- Setting `Cache.DefaultNamespaces` restricts controller-runtime to start informers only in listed namespaces.
- Every cached reconciler read (`ElastiService`, `Service`, `EndpointSlice`, `Pod`) is served from that scoped cache, so no cluster-wide list/watch that would `403` under a namespaced `Role`.
- Scale handler and dynamic informer manager hold their own non-cache clients; only the scale handler did an all-namespaces call, so it now loops per namespace.

## Notes

- Resolver needs no code change; its only API call (`EndpointSlices(ns).List`) is already namespace-scoped. Its RBAC is handled in PR 2 (#315).
- Operator/resolver own namespace is always folded in: leader-election lease and resolver `EndpointSlices` live there; excluding it would silently break scale-from-zero.
- Legacy `--watch-namespace` flag kept working (folded in as single-element list).
