### PR TITLE
[Feat] [PR 3/3] Namespace-scoped docs + e2e test

### DIFF
--- a/docs/src/install/namespace-scoped.md
+++ b/docs/src/install/namespace-scoped.md
@@ -1,0 +1,119 @@
+---
+title: "Namespace-scoped install - run KubeElasti without cluster-wide RBAC"
+description: "Install KubeElasti confined to an explicit list of namespaces using namespace-scoped Role/RoleBinding, with no cluster-wide list/watch. Opt-in via global.allowedNamespaces."
+keywords:
+  - KubeElasti namespace scoped
+  - namespace scoped RBAC
+  - install without cluster admin
+  - allowedNamespaces
+  - WATCH_NAMESPACES
+  - multi-tenant Kubernetes
+icon: lucide/shield-check
+---
+
+# Namespace-scoped install
+
+## What it is
+
+By default KubeElasti installs cluster-scoped: a `ClusterRole` and `ClusterRoleBinding` let the operator and resolver watch every namespace.
+
+Namespace-scoped mode is opt-in. You give KubeElasti an explicit list of namespaces. It then installs a `Role` and `RoleBinding` in each one instead of a `ClusterRole`, and the operator only watches those namespaces. There is no cluster-wide list/watch.
+
+## When to use it
+
+- Multi-tenant clusters where a team may only touch its own namespaces.
+- Regulated or restricted environments that forbid cluster-wide RBAC.
+- You want KubeElasti's blast radius limited to a known set of namespaces.
+
+Use the default cluster-scoped install if none of these apply.
+
+## Prerequisite: install the CRD
+
+Creating a CRD is always a cluster-scoped operation. By default the chart installs the `ElastiService` CRD as part of the release, so a namespace-only install would fail on that step.
+
+A cluster admin installs the CRD once, out of band. Render it from the chart so it matches the release version:
+
+```bash
+helm template elasti oci://ghcr.io/kubeelasti/charts/elasti \
+  --show-only templates/elastiservice-crd.yaml | kubectl apply -f -
+```
+
+After the CRD exists, a tenant with permission only in its own namespaces installs the chart with `global.installCRD=false` (below).
+
+!!! warning "Operator image version"
+    Namespace-scoped mode needs an operator image that supports the `WATCH_NAMESPACES` env var. Use a release that ships this feature. On an older image the chart still renders scoped RBAC, but the operator falls back to cluster-scoped watching and its reads fail under the namespaced `Role`.
+
+## Enable it
+
+Set `global.allowedNamespaces` to the namespaces you want KubeElasti to manage, and turn off CRD install (the admin already applied it):
+
+```bash
+helm install elasti oci://ghcr.io/kubeelasti/charts/elasti \
+  --namespace elasti --create-namespace \
+  --set global.installCRD=false \
+  --set 'global.allowedNamespaces={team-a,team-b}'
+```
+
+If your credentials can manage CRDs, leave `global.installCRD` at its default (`true`) and skip the admin step above.
+
+The release namespace is always added to the list automatically. The operator needs it for the leader-election lease and to read the resolver's `EndpointSlices`.
+
+Leaving `global.allowedNamespaces` empty (the default) keeps the cluster-scoped install unchanged.
+
+## What changes
+
+| | Default (`[]`) | Scoped (list set) |
+|---|---|---|
+| Operator/resolver RBAC | `ClusterRole` + `ClusterRoleBinding` | `Role` + `RoleBinding` per namespace (+ release namespace) |
+| Watched scope | all namespaces | only the listed namespaces |
+| Operator env | none | `WATCH_NAMESPACES` |
+| ClusterRoles created | yes | none |
+
+```mermaid
+flowchart TD
+    A[helm install] --> B{global.allowedNamespaces}
+    B -->|empty, default| C[ClusterRole + ClusterRoleBinding]
+    C --> C2[Operator watches ALL namespaces]
+    B -->|"team-a, team-b"| D[Role + RoleBinding in team-a, team-b, release-ns]
+    D --> D2[WATCH_NAMESPACES env set on operator]
+    D2 --> D3[Operator watches ONLY listed namespaces, no ClusterRoles]
+```
+
+## Verify
+
+No `ClusterRole` or `ClusterRoleBinding` is created in scoped mode:
+
+```bash
+kubectl get clusterrole,clusterrolebinding -l app.kubernetes.io/instance=elasti
+# expect: no resources found
+```
+
+A `Role` and `RoleBinding` exist in each listed namespace:
+
+```bash
+kubectl get role,rolebinding -n team-a -l app.kubernetes.io/instance=elasti
+```
+
+The operator has the namespace list:
+
+```bash
+kubectl get deploy -n elasti -l app.kubernetes.io/component=operator \
+  -o jsonpath='{.items[0].spec.template.spec.containers[0].env}' | grep WATCH_NAMESPACES
+```
+
+An `ElastiService` created in a namespace outside the list is ignored by the operator.
+
+## Uninstall
+
+Same as the default install. Remove ElastiServices first, then the release:
+
+```bash
+kubectl delete elastiservices --all
+helm uninstall elasti -n elasti
+```
+
+The CRD, installed separately by an admin, is removed separately:
+
+```bash
+kubectl delete crd elastiservices.elasti.truefoundry.com
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -255,8 +255,9 @@ nav:
           - Overview: src/about/comparisons/main.md
           - KubeElasti vs KEDA: src/about/comparisons/kubeelasti-vs-keda.md
           - KubeElasti vs Knative: src/about/comparisons/kubeelasti-vs-knative.md
-  - Install: 
+  - Install:
       - Installation: src/install/installation.md
+      - Namespace-scoped install: src/install/namespace-scoped.md
       - Demo setup: src/install/demo-setup.md
       - Pre-Requisites: src/install/pre-requisites.md
       - Configuration: src/install/configure-elastiservice.md

--- a/tests/e2e/tests/14-namespace-scoped/00-scope-elasti.yaml
+++ b/tests/e2e/tests/14-namespace-scoped/00-scope-elasti.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Reconfigure the shared elasti release into namespace-scoped mode, confined to
+  # this test's namespace plus the release namespace (elasti). The chart also folds
+  # in the release namespace on its own; we pass it explicitly for clarity.
+  - script: |
+      cd ../../ && helm upgrade elasti ../../charts/elasti -n elasti \
+        -f ./manifest/global/values-elasti.yaml \
+        --set "global.allowedNamespaces={$NAMESPACE,elasti}" \
+        --wait --timeout 300s
+  - command: kubectl rollout status deployment elasti-operator-controller-manager -n elasti --timeout=300s

--- a/tests/e2e/tests/14-namespace-scoped/01-setup-in-scope.yaml
+++ b/tests/e2e/tests/14-namespace-scoped/01-setup-in-scope.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Deploy the target, KEDA ScaledObject, and ElastiService in this (in-scope) namespace.
+  - command: ../../manifest/setup.sh --manifest-dir ../../manifest
+    namespaced: true
+  - command: sleep 5

--- a/tests/e2e/tests/14-namespace-scoped/02-scale-in-scope.yaml
+++ b/tests/e2e/tests/14-namespace-scoped/02-scale-in-scope.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Scale the in-scope target to zero. The scoped operator watches this namespace,
+  # so it should switch the ElastiService to proxy mode.
+  - command: kubectl scale deployment/target-deployment --replicas=0
+    namespaced: true
+  - command: kubectl wait --for=delete pods -l app=target-deployment --timeout=400s
+    namespaced: true

--- a/tests/e2e/tests/14-namespace-scoped/03-assert.yaml
+++ b/tests/e2e/tests/14-namespace-scoped/03-assert.yaml
@@ -1,0 +1,7 @@
+# In-scope: the scoped operator reconciles this ElastiService and moves it to proxy mode.
+apiVersion: elasti.truefoundry.com/v1alpha1
+kind: ElastiService
+metadata:
+  name: target-elastiservice
+status:
+  mode: proxy

--- a/tests/e2e/tests/14-namespace-scoped/04-out-of-scope.yaml
+++ b/tests/e2e/tests/14-namespace-scoped/04-out-of-scope.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Create a namespace that is NOT in allowedNamespaces, with an ElastiService in it.
+  - script: |
+      kubectl create namespace "$NAMESPACE-oos" --dry-run=client -o yaml | kubectl apply -f -
+      kubectl apply -n "$NAMESPACE-oos" -f oos-elastiservice.yaml

--- a/tests/e2e/tests/14-namespace-scoped/05-verify-scoping.yaml
+++ b/tests/e2e/tests/14-namespace-scoped/05-verify-scoping.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # The out-of-scope ElastiService must be ignored by the scoped operator, so it never
+  # gets a status.mode. The in-scope one already reached proxy (step 03), which proves
+  # the operator is alive and reconciling, so an empty mode here means "ignored", not "slow".
+  - script: |
+      sleep 20
+      mode=$(kubectl get elastiservice target-elastiservice -n "$NAMESPACE-oos" -o jsonpath='{.status.mode}')
+      echo "out-of-scope ElastiService status.mode='$mode' (expected empty)"
+      test -z "$mode"
+  # No cluster-scoped RBAC must exist for elasti in scoped mode.
+  - script: |
+      objs=$(kubectl get clusterrole,clusterrolebinding -l app.kubernetes.io/instance=elasti -o name)
+      echo "elasti cluster-scoped RBAC objects (expected none):"
+      echo "$objs"
+      test -z "$objs"

--- a/tests/e2e/tests/14-namespace-scoped/06-revert.yaml
+++ b/tests/e2e/tests/14-namespace-scoped/06-revert.yaml
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Revert the shared release to cluster-scoped (allowedNamespaces back to default [])
+  # so the cluster is restored for anything that runs after this test.
+  - script: |
+      cd ../../ && helm upgrade elasti ../../charts/elasti -n elasti \
+        -f ./manifest/global/values-elasti.yaml \
+        --wait --timeout 300s
+  - command: kubectl rollout status deployment elasti-operator-controller-manager -n elasti --timeout=300s
+  - script: |
+      kubectl delete namespace "$NAMESPACE-oos" --ignore-not-found=true

--- a/tests/e2e/tests/14-namespace-scoped/oos-elastiservice.yaml
+++ b/tests/e2e/tests/14-namespace-scoped/oos-elastiservice.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: elasti.truefoundry.com/v1alpha1
+kind: ElastiService
+metadata:
+  name: target-elastiservice
+spec:
+  cooldownPeriod: 300
+  minTargetReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: deployments
+    name: target-deployment
+  service: target-deployment
+  triggers:
+    - metadata:
+        query: vector(0)
+        serverAddress: http://prometheus-operated.monitoring.svc.cluster.local:9090
+        threshold: "0.01"
+      type: prometheus


### PR DESCRIPTION
# PR 3/3: Namespace-scoped docs + e2e test

Docs and e2e test for the namespace-scoped feature. Depends on #314 (code) and #315 (chart), which merge into `sd/namespace-scoped` first.

## Change

- New docs page for running KubeElasti confined to a namespace list, wired into the Install nav.
- New kuttl e2e scenario `tests/e2e/tests/14-namespace-scoped`.

## Docs page covers

- When to use scoped mode (multi-tenant, regulated, namespace-confined teams).
- The CRD stays cluster-scoped: the chart installs it, so install/upgrade needs a one-time cluster permission, while operator/resolver RBAC is namespaced.
- Enable with `global.allowedNamespaces`; cluster-scoped vs scoped comparison; a mermaid flow.
- Verify and uninstall.

## E2E scenario

Runs last (index 14) under `parallel: 1`, and reverts at the end:

1. `helm upgrade` the shared release into scoped mode, confined to the test namespace + `elasti`, and restart the operator.
2. Deploy an in-scope target + ElastiService, scale to zero, assert it reaches `mode: proxy` (operator reconciles in-scope).
3. Create an out-of-scope namespace + ElastiService, assert it never gets a `status.mode` (operator ignores it).
4. Assert 0 elasti `ClusterRole`/`ClusterRoleBinding` exist.
5. Revert the release to cluster-scoped and delete the out-of-scope namespace.

## Files

| File | Change |
|------|--------|
| `docs/src/install/namespace-scoped.md` | New page. |
| `mkdocs.yml` | Add the page to the Install nav. |
| `tests/e2e/tests/14-namespace-scoped/*` | New kuttl scenario. |

## Verification

- `zensical build`: docs page renders and is wired into nav; no new warnings.
- The e2e workflow runs on PRs to `main` (not on this PR's `sd/namespace-scoped` base), so it first executes on the `sd/namespace-scoped -> main` PR, where #314's operator code and #315's chart are present together.

