### PR TITLE
release: v0.1.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ## Unreleased
 
+## v0.1.30 (2026-07-23)
+
+### Improvements
+
+* feat: add opt-in namespace-scoped mode. Set `global.allowedNamespaces` (Helm) or the `WATCH_NAMESPACES` operator env var to confine KubeElasti to an explicit list of namespaces using namespace-scoped Role/RoleBinding instead of cluster-wide RBAC. Cluster-scoped stays the default and is unchanged. Adds the `global.installCRD` toggle so an admin can apply the CRD once and let namespace-confined tenants install without cluster-wide permissions by `@ramantehlan` in [#317](https://github.com/KubeElasti/KubeElasti/pull/317)
+
 ## v0.1.30-rc1 (2026-07-22)
 
 ### Breaking Changes

--- a/charts/elasti/Chart.yaml
+++ b/charts/elasti/Chart.yaml
@@ -3,8 +3,8 @@ name: elasti
 description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionality when there is no traffic and automatic scale up to 1 when traffic arrives.
 icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/assets/images/logo/rounded_colour_white_bg.png
 type: application
-version: 0.1.30-rc1
-appVersion: "0.1.30-rc1"
+version: 0.1.30
+appVersion: "0.1.30"
 # kubeVersion: ">=1.25.0-0"
 home: https://kubeelasti.dev
 sources:

--- a/charts/elasti/README.md
+++ b/charts/elasti/README.md
@@ -36,7 +36,7 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 | `elastiController.manager.podSecurityContext`       | pod security context                                   | `{}`                         |
 | `elastiController.manager.image.registry`           | registry to use for the deployment                     | `""`                         |
 | `elastiController.manager.image.repository`         | repository to use for the deployment                   | `kubeelasti/elasti-operator` |
-| `elastiController.manager.image.tag`                | tag to use for the deployment                          | `0.1.30-rc1`                 |
+| `elastiController.manager.image.tag`                | tag to use for the deployment                          | `0.1.30`                     |
 | `elastiController.manager.imagePullPolicy`          | image pull policy                                      | `IfNotPresent`               |
 | `elastiController.manager.resources`                | resources to use for the deployment                    | `{}`                         |
 | `elastiController.manager.sentry.enabled`           | whether to enable sentry                               | `false`                      |
@@ -71,7 +71,7 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 | `elastiResolver.proxy.env`                                  | environment to use for the deployment                       | `{}`                         |
 | `elastiResolver.proxy.image.registry`                       | registry to use for the deployment                          | `""`                         |
 | `elastiResolver.proxy.image.repository`                     | repository to use for the deployment                        | `kubeelasti/elasti-resolver` |
-| `elastiResolver.proxy.image.tag`                            | tag to use for the deployment                               | `0.1.30-rc1`                 |
+| `elastiResolver.proxy.image.tag`                            | tag to use for the deployment                               | `0.1.30`                     |
 | `elastiResolver.proxy.imagePullPolicy`                      | image pull policy                                           | `IfNotPresent`               |
 | `elastiResolver.proxy.resources`                            | resources to use for the deployment                         | `{}`                         |
 | `elastiResolver.proxy.containerSecurityContext`             | container security context                                  | `{}`                         |

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -87,7 +87,7 @@ elastiController:
       repository: kubeelasti/elasti-operator
       ## @param elastiController.manager.image.tag tag to use for the deployment
       ##
-      tag: 0.1.30-rc1
+      tag: 0.1.30
     ## @param elastiController.manager.imagePullPolicy image pull policy
     ##
     imagePullPolicy: IfNotPresent
@@ -213,7 +213,7 @@ elastiResolver:
       repository: kubeelasti/elasti-resolver
       ## @param elastiResolver.proxy.image.tag tag to use for the deployment
       ##
-      tag: 0.1.30-rc1
+      tag: 0.1.30
     ## @param elastiResolver.proxy.imagePullPolicy image pull policy
     ##
     imagePullPolicy: IfNotPresent

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -10,6 +10,35 @@ entries:
           url: https://slack.cncf.io/
       artifacthub.io/operator: "true"
     apiVersion: v2
+    appVersion: 0.1.30
+    created: "2026-07-23T17:13:10.365735529Z"
+    description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
+      functionality when there is no traffic and automatic scale up to 1 when traffic
+      arrives.
+    digest: 4c90f1e024bcda154ef7a5be2717a07237ed80856a0ea5a9b441341eff7e435e
+    home: https://kubeelasti.dev
+    icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/assets/images/logo/rounded_colour_white_bg.png
+    keywords:
+    - Scale-to-zero
+    - Operator
+    - Cloud Native
+    - Autoscaling
+    name: elasti
+    sources:
+    - https://github.com/KubeElasti/KubeElasti
+    type: application
+    urls:
+    - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.30/elasti-0.1.30.tgz
+    version: 0.1.30
+  - annotations:
+      artifacthub.io/license: MIT
+      artifacthub.io/links: |
+        - name: Source
+          url: https://github.com/KubeElasti/KubeElasti
+        - name: CNCF Slack (#kubeelasti)
+          url: https://slack.cncf.io/
+      artifacthub.io/operator: "true"
+    apiVersion: v2
     appVersion: 0.1.30-rc1
     created: "2026-07-22T12:24:20.557780337Z"
     description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
@@ -185,4 +214,4 @@ entries:
     urls:
     - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.20/elasti-0.1.20.tgz
     version: 0.1.20
-generated: "2026-07-22T12:24:20.556654668Z"
+generated: "2026-07-23T17:13:10.364607182Z"


### PR DESCRIPTION
Release v0.1.30.

Graduates `v0.1.30-rc1` to stable and ships the namespace-scoped feature from #317.

## Changes

- `charts/elasti/Chart.yaml`: `version` and `appVersion` -> `0.1.30`
- `charts/elasti/values.yaml`: operator and resolver image tags -> `0.1.30`
- `CHANGELOG.md`: new `v0.1.30` section (namespace-scoped mode, #317)

## Notes

- Changelog lists only the new change in this release (#317). The full comparison against the last stable (v0.1.25) goes in the GitHub release notes.
- `charts/elasti/README.md` and `docs/index.yaml` are regenerated by CI, not hand-edited.
- Merge #317 before this release commit lands so the referenced feature is present on `main`.
