### PR TITLE
feat: add Go code coverage via Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,38 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: operator
+      paths:
+        - operator/
+    - name: resolver
+      paths:
+        - resolver/
+    - name: pkg
+      paths:
+        - pkg/
+
+ignore:
+  - "**/*_test.go"
+  - "**/zz_generated.*.go"
+  - "**/mock_*.go"
+  - "operator/api/**"
+  - "tests/**"
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,58 @@
+name: Code coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'operator/**'
+      - 'resolver/**'
+      - 'pkg/**'
+      - '*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'go.work'
+      - 'go.work.sum'
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: 1.26.5
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: operator
+          - module: resolver
+          - module: pkg
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Install dependencies
+        run: go mod tidy
+        working-directory: ${{ matrix.module }}
+      - name: Run tests with coverage
+        run: cd ${{ matrix.module }} && make test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.module }}/cover.out
+          flags: ${{ matrix.module }}
+          name: ${{ matrix.module }}
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ venv
 
 # Logs
 *.log
+cosign.key
+
+# Go coverage profiles
+cover.out
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 
 ![Lint and Test](https://github.com/KubeElasti/KubeElasti/actions/workflows/lint-and-test.yaml/badge.svg)
+[![codecov](https://codecov.io/gh/KubeElasti/KubeElasti/branch/main/graph/badge.svg)](https://codecov.io/gh/KubeElasti/KubeElasti)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kubeelasti)](https://artifacthub.io/packages/search?repo=kubeelasti)
 [![CNCF Landscape](https://img.shields.io/badge/CNCF%20Landscape-5699C6)](https://landscape.cncf.io/?item=serverless--framework--kubeelasti)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12491/badge)](https://www.bestpractices.dev/projects/12491)

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -18,5 +18,5 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: fmt vet ## Run tests.
-	go test ./... -race
+	go test ./... -race -coverprofile=cover.out -covermode=atomic
 

--- a/resolver/Makefile
+++ b/resolver/Makefile
@@ -24,7 +24,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: fmt vet ## Run tests.
-	go test ./... -race
+	go test ./... -race -coverprofile=cover.out -covermode=atomic
 
 .PHONY: run
 run: ## Run resolver locally


### PR DESCRIPTION
## What

Adds Go code coverage reporting via Codecov for all three modules (`operator`, `resolver`, `pkg`).

## Changes

- **`.github/workflows/coverage.yaml`** - new workflow (push/PR to `main`, same path filters as lint-and-test). Matrix job over the three modules: sets up Go, `go mod tidy`, `make test`, uploads each module's `cover.out` to Codecov with a per-module flag.
- **`.codecov.yml`** - per-module flags with carryforward, `informational` project/patch status (won't block CI while baselines settle), and ignores for test files, generated code (`zz_generated.*`, `mock_*`, `operator/api/**`), and `tests/`.
- **`resolver/Makefile`, `pkg/Makefile`** - `test` target now emits `-coverprofile=cover.out -covermode=atomic` (operator already emitted `cover.out`).
- **`.gitignore`** - ignore `cover.out` at repo root.
- **`README.md`** - added Codecov badge.
