### PR TITLE
fix: harden Prometheus scaler against SSRF (CWE-918)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ### Fixes
 
-* fix: harden the Prometheus scaler against SSRF (CWE-918). The operator now refuses outbound scaler requests to loopback, link-local, and cloud metadata addresses (IPv4 `169.254.169.254`) at dial time, rejects HTTP redirects, and no longer lets a trigger's `metadata.headers` override the operator-configured `Authorization` header. A new optional `PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES` operator env var (Helm: `elastiController.manager.env.prometheusTriggerAllowedServerAddresses`) restricts which Prometheus hosts an `ElastiService` trigger may target; when set it is the sole gate on the destination (an explicitly allowed host is reachable even if it would otherwise be blocked) by `@ramantehlan` in [#319](https://github.com/KubeElasti/KubeElasti/pull/319)
+* fix: harden the Prometheus scaler against SSRF (CWE-918). The operator now refuses outbound scaler requests to loopback, link-local, and cloud metadata addresses (IPv4 `169.254.169.254`) at dial time, rejects HTTP redirects, and no longer lets a trigger's `metadata.headers` override the operator-configured `Authorization` header. A new optional `PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES` operator env var (Helm: `elastiController.manager.env.prometheusTriggerAllowedServerAddresses`) restricts which Prometheus hosts an `ElastiService` trigger may target; when set it is the sole gate on the destination (an explicitly allowed host is reachable even if it would otherwise be blocked) by `@ramantehlan` in [#324](https://github.com/KubeElasti/KubeElasti/pull/324)
 
 ## v0.1.30 (2026-07-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ## Unreleased
 
+### Fixes
+
+* fix: harden the Prometheus scaler against SSRF (CWE-918). The operator now refuses outbound scaler requests to loopback, link-local, and cloud metadata addresses (IPv4 `169.254.169.254`) at dial time, rejects HTTP redirects, and no longer lets a trigger's `metadata.headers` override the operator-configured `Authorization` header. A new optional `PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES` operator env var (Helm: `elastiController.manager.env.prometheusTriggerAllowedServerAddresses`) restricts which Prometheus hosts an `ElastiService` trigger may target; when set it is the sole gate on the destination (an explicitly allowed host is reachable even if it would otherwise be blocked) by `@ramantehlan` in [#319](https://github.com/KubeElasti/KubeElasti/pull/319)
+
 ## v0.1.30 (2026-07-23)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ### Fixes
 
-* fix: harden the Prometheus scaler against SSRF (CWE-918). The operator now refuses outbound scaler requests to loopback, link-local, and cloud metadata addresses (IPv4 `169.254.169.254`) at dial time, rejects HTTP redirects, and no longer lets a trigger's `metadata.headers` override the operator-configured `Authorization` header. A new optional `PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES` operator env var (Helm: `elastiController.manager.env.prometheusTriggerAllowedServerAddresses`) restricts which Prometheus hosts an `ElastiService` trigger may target; when set it is the sole gate on the destination (an explicitly allowed host is reachable even if it would otherwise be blocked) by `@ramantehlan` in [#324](https://github.com/KubeElasti/KubeElasti/pull/324)
+* fix: harden the Prometheus scaler against SSRF (CWE-918). The operator now refuses outbound scaler requests to loopback, link-local, and multicast addresses at dial time and rejects HTTP redirects. A new optional `PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES` operator env var (Helm: `elastiController.manager.env.prometheusTriggerAllowedServerAddresses`) restricts which Prometheus hosts an `ElastiService` trigger may target; when set it is the sole gate on the destination (an explicitly allowed host is reachable even if it would otherwise be blocked) by `@ramantehlan` in [#324](https://github.com/KubeElasti/KubeElasti/pull/324)
 
 ## v0.1.30 (2026-07-23)
 

--- a/charts/elasti/templates/deployment.yaml
+++ b/charts/elasti/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
         - name: PROMETHEUS_TRIGGER_AUTHORIZATION_HEADER
           value: {{ . | quote }}
         {{- end }}
+        {{- with .Values.elastiController.manager.env.prometheusTriggerAllowedServerAddresses }}
+        - name: PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES
+          value: {{ . | quote }}
+        {{- end }}
         {{- if .Values.elastiController.manager.sentry.enabled }}
         - name: SENTRY_DSN
           valueFrom:

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -124,6 +124,12 @@ elastiController:
       # e.g. prometheusTriggerAuthorizationHeader: Basic xxx
       ##
       prometheusTriggerAuthorizationHeader:
+      ## elastiController.manager.env.prometheusTriggerAllowedServerAddresses: optional comma-separated allowlist of Prometheus hosts (host or host:port)
+      # that an ElastiService trigger may set as serverAddress. When empty, any serverAddress is accepted (still protected against SSRF to
+      # loopback/link-local/cloud-metadata addresses). Set this to restrict which Prometheus endpoints tenants can point the operator at.
+      # e.g. prometheusTriggerAllowedServerAddresses: prometheus-operated.monitoring.svc.cluster.local:9090
+      ##
+      prometheusTriggerAllowedServerAddresses:
 
   ## @param elastiController.replicas number of replicas to use for the deployment
   ##

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -126,7 +126,7 @@ elastiController:
       prometheusTriggerAuthorizationHeader:
       ## elastiController.manager.env.prometheusTriggerAllowedServerAddresses: optional comma-separated allowlist of Prometheus hosts (host or host:port)
       # that an ElastiService trigger may set as serverAddress. When empty, any serverAddress is accepted (still protected against SSRF to
-      # loopback/link-local/cloud-metadata addresses). Set this to restrict which Prometheus endpoints tenants can point the operator at.
+      # loopback/link-local/multicast addresses). Set this to restrict which Prometheus endpoints tenants can point the operator at.
       # e.g. prometheusTriggerAllowedServerAddresses: prometheus-operated.monitoring.svc.cluster.local:9090
       ##
       prometheusTriggerAllowedServerAddresses:

--- a/pkg/scaling/scalers/prometheus_scaler.go
+++ b/pkg/scaling/scalers/prometheus_scaler.go
@@ -78,8 +78,8 @@ func NewPrometheusScaler(metadata json.RawMessage, cooldownPeriod time.Duration)
 // rejected outright since the Prometheus query API never issues them. When
 // dialGuard is true, the dialer also inspects the concrete IP being connected
 // to (after DNS resolution, so hostname- and redirect-based bypasses are
-// covered too) and refuses never-legitimate targets such as loopback and the
-// cloud metadata service.
+// covered too) and refuses never-legitimate targets such as loopback,
+// link-local, and multicast addresses.
 func newHTTPClient(dialGuard bool) *http.Client {
 	transport := &http.Transport{}
 	if dialGuard {
@@ -180,13 +180,11 @@ func (s *prometheusScaler) executePromQuery(ctx context.Context, query string) (
 		return -1, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
-	// Apply per-trigger metadata headers first, then operator-configured default
-	// headers, so a default (e.g. Authorization) can never be overridden by a
-	// CRD-supplied header.
-	for key, value := range s.metadata.Headers {
+	// Apply default headers, then per-trigger metadata headers (which can override defaults)
+	for key, value := range s.defaultHeaders {
 		req.Header.Set(key, value)
 	}
-	for key, value := range s.defaultHeaders {
+	for key, value := range s.metadata.Headers {
 		req.Header.Set(key, value)
 	}
 

--- a/pkg/scaling/scalers/prometheus_scaler.go
+++ b/pkg/scaling/scalers/prometheus_scaler.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -25,6 +27,10 @@ type prometheusScaler struct {
 	cooldownPeriod       time.Duration
 	defaultServerAddress string
 	defaultHeaders       map[string]string
+	// allowedServerAddresses is an optional admin-configured allowlist of hosts
+	// (host or host:port) that a CRD-supplied serverAddress must match. When
+	// empty, any serverAddress is accepted (still subject to the dial guard).
+	allowedServerAddresses []string
 }
 
 type prometheusMetadata struct {
@@ -52,17 +58,84 @@ func NewPrometheusScaler(metadata json.RawMessage, cooldownPeriod time.Duration)
 		return nil, fmt.Errorf("error creating prometheus scaler: %w", err)
 	}
 
-	client := &http.Client{
-		Timeout: httpClientTimeout,
-	}
+	allowedServerAddresses := fetchAllowedServerAddresses()
 
 	return &prometheusScaler{
-		metadata:             parsedMetadata,
-		httpClient:           client,
-		cooldownPeriod:       cooldownPeriod,
-		defaultServerAddress: os.Getenv("PROMETHEUS_TRIGGER_SERVER_ADDRESS"),
-		defaultHeaders:       fetchDefaultHeaders(),
+		metadata: parsedMetadata,
+		// When an admin allowlist is configured it is the sole gate on the
+		// destination (allowlist beats blocklist), so the dial guard is disabled
+		// and an explicitly-allowed host is reachable even if it is otherwise
+		// blocked. Without an allowlist, the dial guard is the protection.
+		httpClient:             newHTTPClient(len(allowedServerAddresses) == 0),
+		cooldownPeriod:         cooldownPeriod,
+		defaultServerAddress:   os.Getenv("PROMETHEUS_TRIGGER_SERVER_ADDRESS"),
+		defaultHeaders:         fetchDefaultHeaders(),
+		allowedServerAddresses: allowedServerAddresses,
 	}, nil
+}
+
+// newHTTPClient builds an http.Client hardened against SSRF. Redirects are
+// rejected outright since the Prometheus query API never issues them. When
+// dialGuard is true, the dialer also inspects the concrete IP being connected
+// to (after DNS resolution, so hostname- and redirect-based bypasses are
+// covered too) and refuses never-legitimate targets such as loopback and the
+// cloud metadata service.
+func newHTTPClient(dialGuard bool) *http.Client {
+	transport := &http.Transport{}
+	if dialGuard {
+		dialer := &net.Dialer{
+			Control: func(_, address string, _ syscall.RawConn) error {
+				host, _, err := net.SplitHostPort(address)
+				if err != nil {
+					return fmt.Errorf("failed to parse dial address %q: %w", address, err)
+				}
+				ip := net.ParseIP(host)
+				if ip == nil {
+					return fmt.Errorf("failed to parse dial IP %q", host)
+				}
+				if isBlockedIP(ip) {
+					return fmt.Errorf("connection to %s blocked to prevent SSRF", ip)
+				}
+				return nil
+			},
+		}
+		transport.DialContext = dialer.DialContext
+	}
+
+	return &http.Client{
+		Timeout:   httpClientTimeout,
+		Transport: transport,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return fmt.Errorf("redirects are not allowed")
+		},
+	}
+}
+
+// isBlockedIP reports whether an IP is a never-legitimate Prometheus target.
+// Private ranges are intentionally allowed: an in-cluster Prometheus is reached
+// via a private ClusterIP or a *.svc.cluster.local name resolving to one.
+func isBlockedIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast()
+}
+
+// fetchAllowedServerAddresses parses the optional operator allowlist.
+func fetchAllowedServerAddresses() []string {
+	raw := os.Getenv("PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES")
+	if raw == "" {
+		return nil
+	}
+
+	allowed := make([]string, 0)
+	for _, addr := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(addr); trimmed != "" {
+			allowed = append(allowed, trimmed)
+		}
+	}
+	return allowed
 }
 
 func fetchDefaultHeaders() map[string]string {
@@ -96,12 +169,9 @@ func queryEscape(query string) string {
 func (s *prometheusScaler) executePromQuery(ctx context.Context, query string) (float64, error) {
 	t := time.Now().UTC().Format(time.RFC3339)
 	queryEscaped := queryEscape(query)
-	serverAddress := s.defaultServerAddress
-	if s.metadata.ServerAddress != "" {
-		serverAddress = s.metadata.ServerAddress
-	}
-	if serverAddress == "" {
-		return -1, fmt.Errorf("prometheus serverAddress not configured")
+	serverAddress, err := s.resolveServerAddress()
+	if err != nil {
+		return -1, err
 	}
 	queryURL := fmt.Sprintf("%s/api/v1/query?query=%s&time=%s", serverAddress, queryEscaped, t)
 
@@ -110,11 +180,13 @@ func (s *prometheusScaler) executePromQuery(ctx context.Context, query string) (
 		return -1, fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
-	// Apply default headers, then per-trigger metadata headers (which can override defaults)
-	for key, value := range s.defaultHeaders {
+	// Apply per-trigger metadata headers first, then operator-configured default
+	// headers, so a default (e.g. Authorization) can never be overridden by a
+	// CRD-supplied header.
+	for key, value := range s.metadata.Headers {
 		req.Header.Set(key, value)
 	}
-	for key, value := range s.metadata.Headers {
+	for key, value := range s.defaultHeaders {
 		req.Header.Set(key, value)
 	}
 
@@ -161,6 +233,46 @@ func (s *prometheusScaler) executePromQuery(ctx context.Context, query string) (
 	}
 
 	return v, nil
+}
+
+// resolveServerAddress picks the effective Prometheus address. A CRD-supplied
+// serverAddress takes precedence over the operator default, but when an admin
+// allowlist is configured the CRD host must be present in it.
+func (s *prometheusScaler) resolveServerAddress() (string, error) {
+	if s.metadata.ServerAddress == "" {
+		if s.defaultServerAddress == "" {
+			return "", fmt.Errorf("prometheus serverAddress not configured")
+		}
+		return s.defaultServerAddress, nil
+	}
+
+	if err := s.checkServerAddressAllowed(s.metadata.ServerAddress); err != nil {
+		return "", err
+	}
+	return s.metadata.ServerAddress, nil
+}
+
+// checkServerAddressAllowed enforces the optional admin allowlist against a
+// CRD-supplied serverAddress. A match on either host or host:port is accepted.
+// When the allowlist is empty the address is accepted (dial guard still applies).
+func (s *prometheusScaler) checkServerAddressAllowed(serverAddress string) error {
+	if len(s.allowedServerAddresses) == 0 {
+		return nil
+	}
+
+	u, err := url.Parse(serverAddress)
+	if err != nil {
+		return fmt.Errorf("failed to parse serverAddress %q: %w", serverAddress, err)
+	}
+	host := u.Hostname()
+	hostPort := u.Host
+
+	for _, allowed := range s.allowedServerAddresses {
+		if allowed == host || allowed == hostPort {
+			return nil
+		}
+	}
+	return fmt.Errorf("serverAddress %q is not in the allowed list", serverAddress)
 }
 
 func (s *prometheusScaler) ShouldScaleToZero(ctx context.Context) (bool, error) {

--- a/pkg/scaling/scalers/prometheus_scaler.go
+++ b/pkg/scaling/scalers/prometheus_scaler.go
@@ -169,7 +169,10 @@ func queryEscape(query string) string {
 func (s *prometheusScaler) executePromQuery(ctx context.Context, query string) (float64, error) {
 	t := time.Now().UTC().Format(time.RFC3339)
 	queryEscaped := queryEscape(query)
-	serverAddress, err := s.resolveServerAddress()
+	if err := s.validateServerAddress(); err != nil {
+		return -1, err
+	}
+	serverAddress, err := s.getServerAddress()
 	if err != nil {
 		return -1, err
 	}
@@ -233,34 +236,30 @@ func (s *prometheusScaler) executePromQuery(ctx context.Context, query string) (
 	return v, nil
 }
 
-// resolveServerAddress picks the effective Prometheus address. A CRD-supplied
-// serverAddress takes precedence over the operator default, but when an admin
-// allowlist is configured the CRD host must be present in it.
-func (s *prometheusScaler) resolveServerAddress() (string, error) {
-	if s.metadata.ServerAddress == "" {
-		if s.defaultServerAddress == "" {
-			return "", fmt.Errorf("prometheus serverAddress not configured")
-		}
-		return s.defaultServerAddress, nil
+// getServerAddress returns the effective Prometheus address: the CRD-supplied
+// serverAddress when present, otherwise the operator-configured default.
+func (s *prometheusScaler) getServerAddress() (string, error) {
+	if s.metadata.ServerAddress != "" {
+		return s.metadata.ServerAddress, nil
 	}
-
-	if err := s.checkServerAddressAllowed(s.metadata.ServerAddress); err != nil {
-		return "", err
+	if s.defaultServerAddress == "" {
+		return "", fmt.Errorf("prometheus serverAddress not configured")
 	}
-	return s.metadata.ServerAddress, nil
+	return s.defaultServerAddress, nil
 }
 
-// checkServerAddressAllowed enforces the optional admin allowlist against a
-// CRD-supplied serverAddress. A match on either host or host:port is accepted.
-// When the allowlist is empty the address is accepted (dial guard still applies).
-func (s *prometheusScaler) checkServerAddressAllowed(serverAddress string) error {
-	if len(s.allowedServerAddresses) == 0 {
+// validateServerAddress enforces the optional admin allowlist against a
+// CRD-supplied serverAddress, matching on either host or host:port. It is a
+// no-op when no CRD override is set or no allowlist is configured; the operator
+// default is always trusted.
+func (s *prometheusScaler) validateServerAddress() error {
+	if s.metadata.ServerAddress == "" || len(s.allowedServerAddresses) == 0 {
 		return nil
 	}
 
-	u, err := url.Parse(serverAddress)
+	u, err := url.Parse(s.metadata.ServerAddress)
 	if err != nil {
-		return fmt.Errorf("failed to parse serverAddress %q: %w", serverAddress, err)
+		return fmt.Errorf("failed to parse serverAddress %q: %w", s.metadata.ServerAddress, err)
 	}
 	host := u.Hostname()
 	hostPort := u.Host
@@ -270,7 +269,7 @@ func (s *prometheusScaler) checkServerAddressAllowed(serverAddress string) error
 			return nil
 		}
 	}
-	return fmt.Errorf("serverAddress %q is not in the allowed list", serverAddress)
+	return fmt.Errorf("serverAddress %q is not in the allowed list", s.metadata.ServerAddress)
 }
 
 func (s *prometheusScaler) ShouldScaleToZero(ctx context.Context) (bool, error) {

--- a/pkg/scaling/scalers/prometheus_scaler.go
+++ b/pkg/scaling/scalers/prometheus_scaler.go
@@ -169,11 +169,11 @@ func queryEscape(query string) string {
 func (s *prometheusScaler) executePromQuery(ctx context.Context, query string) (float64, error) {
 	t := time.Now().UTC().Format(time.RFC3339)
 	queryEscaped := queryEscape(query)
-	if err := s.validateServerAddress(); err != nil {
-		return -1, err
-	}
 	serverAddress, err := s.getServerAddress()
 	if err != nil {
+		return -1, err
+	}
+	if err := s.validateServerAddress(serverAddress); err != nil {
 		return -1, err
 	}
 	queryURL := fmt.Sprintf("%s/api/v1/query?query=%s&time=%s", serverAddress, queryEscaped, t)
@@ -248,18 +248,18 @@ func (s *prometheusScaler) getServerAddress() (string, error) {
 	return s.defaultServerAddress, nil
 }
 
-// validateServerAddress enforces the optional admin allowlist against a
-// CRD-supplied serverAddress, matching on either host or host:port. It is a
-// no-op when no CRD override is set or no allowlist is configured; the operator
-// default is always trusted.
-func (s *prometheusScaler) validateServerAddress() error {
-	if s.metadata.ServerAddress == "" || len(s.allowedServerAddresses) == 0 {
+// validateServerAddress enforces the optional admin allowlist against the
+// effective server address, matching on either host or host:port. The operator
+// default is always trusted, and an empty allowlist accepts any address; only a
+// non-default address absent from a configured allowlist is rejected.
+func (s *prometheusScaler) validateServerAddress(serverAddress string) error {
+	if serverAddress == s.defaultServerAddress || len(s.allowedServerAddresses) == 0 {
 		return nil
 	}
 
-	u, err := url.Parse(s.metadata.ServerAddress)
+	u, err := url.Parse(serverAddress)
 	if err != nil {
-		return fmt.Errorf("failed to parse serverAddress %q: %w", s.metadata.ServerAddress, err)
+		return fmt.Errorf("failed to parse serverAddress %q: %w", serverAddress, err)
 	}
 	host := u.Hostname()
 	hostPort := u.Host
@@ -269,7 +269,7 @@ func (s *prometheusScaler) validateServerAddress() error {
 			return nil
 		}
 	}
-	return fmt.Errorf("serverAddress %q is not in the allowed list", s.metadata.ServerAddress)
+	return fmt.Errorf("serverAddress %q is not in the allowed list", serverAddress)
 }
 
 func (s *prometheusScaler) ShouldScaleToZero(ctx context.Context) (bool, error) {

--- a/pkg/scaling/scalers/prometheus_scaler.go
+++ b/pkg/scaling/scalers/prometheus_scaler.go
@@ -85,18 +85,7 @@ func newHTTPClient(dialGuard bool) *http.Client {
 	if dialGuard {
 		dialer := &net.Dialer{
 			Control: func(_, address string, _ syscall.RawConn) error {
-				host, _, err := net.SplitHostPort(address)
-				if err != nil {
-					return fmt.Errorf("failed to parse dial address %q: %w", address, err)
-				}
-				ip := net.ParseIP(host)
-				if ip == nil {
-					return fmt.Errorf("failed to parse dial IP %q", host)
-				}
-				if isBlockedIP(ip) {
-					return fmt.Errorf("connection to %s blocked to prevent SSRF", ip)
-				}
-				return nil
+				return guardDialAddress(address)
 			},
 		}
 		transport.DialContext = dialer.DialContext
@@ -109,6 +98,24 @@ func newHTTPClient(dialGuard bool) *http.Client {
 			return fmt.Errorf("redirects are not allowed")
 		},
 	}
+}
+
+// guardDialAddress rejects a "host:port" dial target whose IP is a
+// never-legitimate Prometheus destination. It runs after DNS resolution, so it
+// also covers hostnames that resolve to a blocked IP and redirect targets.
+func guardDialAddress(address string) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("failed to parse dial address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("failed to parse dial IP %q", host)
+	}
+	if isBlockedIP(ip) {
+		return fmt.Errorf("connection to %s blocked to prevent SSRF", ip)
+	}
+	return nil
 }
 
 // isBlockedIP reports whether an IP is a never-legitimate Prometheus target.

--- a/pkg/scaling/scalers/prometheus_scaler_test.go
+++ b/pkg/scaling/scalers/prometheus_scaler_test.go
@@ -2,6 +2,7 @@ package scalers
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -139,6 +140,7 @@ func TestValidateServerAddress(t *testing.T) {
 		{name: "host:port match", addr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring:9090"}},
 		{name: "rejects unlisted host", addr: "http://request-catcher.evil:9090", allowed: []string{"prom.monitoring"}, wantErr: true},
 		{name: "default is allowed despite non-matching allowlist", addr: "http://d:9090", defaultAddr: "http://d:9090", allowed: []string{"prom.monitoring"}},
+		{name: "unparseable address is rejected", addr: "http://\x00", allowed: []string{"prom.monitoring"}, wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -184,5 +186,300 @@ func TestExecutePromQueryCRDHeaderWins(t *testing.T) {
 	}
 	if auth := <-gotAuth; auth != "crd-token" {
 		t.Errorf("Authorization header = %q, want per-trigger CRD header to win", auth)
+	}
+}
+
+func TestGuardDialAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr bool
+	}{
+		{name: "missing port", addr: "127.0.0.1", wantErr: true},
+		{name: "non-IP host", addr: "notanip:80", wantErr: true},
+		{name: "blocked loopback", addr: "127.0.0.1:80", wantErr: true},
+		{name: "allowed private", addr: "10.0.0.1:80", wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := guardDialAddress(tt.addr)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewPrometheusScaler(t *testing.T) {
+	t.Run("valid metadata", func(t *testing.T) {
+		sc, err := NewPrometheusScaler(json.RawMessage(`{"serverAddress":"http://p:9090","query":"up","threshold":"1"}`), time.Minute)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if sc == nil {
+			t.Fatal("expected a scaler, got nil")
+		}
+	})
+
+	t.Run("invalid metadata errors", func(t *testing.T) {
+		if _, err := NewPrometheusScaler(json.RawMessage(`{bad`), time.Minute); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("allowlist is parsed from env", func(t *testing.T) {
+		t.Setenv("PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES", "prom.monitoring")
+		sc, err := NewPrometheusScaler(json.RawMessage(`{"query":"up","threshold":"1"}`), time.Minute)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := sc.(*prometheusScaler).allowedServerAddresses; len(got) != 1 || got[0] != "prom.monitoring" {
+			t.Fatalf("allowedServerAddresses = %v, want [prom.monitoring]", got)
+		}
+	})
+}
+
+func TestFetchDefaultHeaders(t *testing.T) {
+	t.Run("unset returns empty", func(t *testing.T) {
+		t.Setenv("PROMETHEUS_TRIGGER_AUTHORIZATION_HEADER", "")
+		if h := fetchDefaultHeaders(); len(h) != 0 {
+			t.Fatalf("headers = %v, want empty", h)
+		}
+	})
+
+	t.Run("set returns Authorization", func(t *testing.T) {
+		t.Setenv("PROMETHEUS_TRIGGER_AUTHORIZATION_HEADER", "Bearer x")
+		if h := fetchDefaultHeaders(); h["Authorization"] != "Bearer x" {
+			t.Fatalf("headers = %v, want Authorization=Bearer x", h)
+		}
+	})
+}
+
+func TestFetchAllowedServerAddresses(t *testing.T) {
+	t.Run("unset returns nil", func(t *testing.T) {
+		t.Setenv("PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES", "")
+		if got := fetchAllowedServerAddresses(); got != nil {
+			t.Fatalf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("parsed, trimmed, empties dropped", func(t *testing.T) {
+		t.Setenv("PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES", " a , ,b ")
+		got := fetchAllowedServerAddresses()
+		if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Fatalf("got %v, want [a b]", got)
+		}
+	})
+}
+
+// promServer starts an httptest server returning a fixed status and body.
+func promServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// plainScaler builds a scaler with a plain http.Client (no dial guard), since
+// httptest servers listen on loopback which the guard would otherwise block.
+func plainScaler(serverURL string) *prometheusScaler {
+	return &prometheusScaler{
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		metadata:   &prometheusMetadata{ServerAddress: serverURL},
+	}
+}
+
+// okVal is a well-formed single-vector Prometheus response carrying value v.
+func okVal(v string) string {
+	return `{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"` + v + `"]}]}}`
+}
+
+func TestExecutePromQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		want    float64
+		wantErr bool
+	}{
+		{name: "single value", status: 200, body: okVal("1"), want: 1},
+		{name: "null value returns -1", status: 200, body: `{"data":{"result":[{"value":[1,null]}]}}`, want: -1},
+		{name: "non-200 status", status: 500, body: "", wantErr: true},
+		{name: "invalid json", status: 200, body: "not-json", wantErr: true},
+		{name: "empty result", status: 200, body: `{"data":{"result":[]}}`, wantErr: true},
+		{name: "multiple results", status: 200, body: `{"data":{"result":[{"value":[1,"1"]},{"value":[1,"2"]}]}}`, wantErr: true},
+		{name: "empty value list", status: 200, body: `{"data":{"result":[{"value":[]}]}}`, wantErr: true},
+		{name: "too few values", status: 200, body: `{"data":{"result":[{"value":[1]}]}}`, wantErr: true},
+		{name: "non-numeric value", status: 200, body: `{"data":{"result":[{"value":[1,"abc"]}]}}`, wantErr: true},
+		{name: "infinite value", status: 200, body: okVal("+Inf"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := promServer(t, tt.status, tt.body)
+			got, err := plainScaler(srv.URL).executePromQuery(context.Background(), "up")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got value %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("executePromQuery() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecutePromQueryRequestErrors(t *testing.T) {
+	t.Run("no address configured", func(t *testing.T) {
+		s := &prometheusScaler{metadata: &prometheusMetadata{}, httpClient: &http.Client{}}
+		if _, err := s.executePromQuery(context.Background(), "up"); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("address not in allowlist", func(t *testing.T) {
+		s := &prometheusScaler{
+			metadata:               &prometheusMetadata{ServerAddress: "http://evil:9090"},
+			allowedServerAddresses: []string{"prom.monitoring"},
+			httpClient:             &http.Client{},
+		}
+		if _, err := s.executePromQuery(context.Background(), "up"); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid request url", func(t *testing.T) {
+		if _, err := plainScaler("http://\x00bad").executePromQuery(context.Background(), "up"); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("connection refused", func(t *testing.T) {
+		if _, err := plainScaler("http://127.0.0.1:1").executePromQuery(context.Background(), "up"); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestShouldScaleToZero(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    bool
+		wantErr bool
+	}{
+		{name: "below threshold scales to zero", body: okVal("0"), want: true},
+		{name: "at or above threshold stays", body: okVal("2"), want: false},
+		{name: "unavailable metric does not scale", body: `{"data":{"result":[{"value":[1,null]}]}}`, want: false},
+		{name: "query error", body: "bad", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := promServer(t, 200, tt.body)
+			s := plainScaler(srv.URL)
+			s.metadata.Query = "up"
+			s.metadata.Threshold = 1
+			got, err := s.ShouldScaleToZero(context.Background())
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("ShouldScaleToZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldScaleFromZero(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    bool
+		wantErr bool
+	}{
+		{name: "at or above threshold scales", body: okVal("2"), want: true},
+		{name: "below threshold does not scale", body: okVal("0"), want: false},
+		{name: "unavailable metric scales", body: `{"data":{"result":[{"value":[1,null]}]}}`, want: true},
+		{name: "query error scales and returns error", body: "bad", want: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := promServer(t, 200, tt.body)
+			s := plainScaler(srv.URL)
+			s.metadata.Query = "up"
+			s.metadata.Threshold = 1
+			got, err := s.ShouldScaleFromZero(context.Background())
+			if got != tt.want {
+				t.Errorf("ShouldScaleFromZero() = %v, want %v", got, tt.want)
+			}
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestIsHealthy(t *testing.T) {
+	t.Run("healthy when uptime is 1 (default filter)", func(t *testing.T) {
+		srv := promServer(t, 200, okVal("1"))
+		s := plainScaler(srv.URL)
+		s.cooldownPeriod = time.Minute
+		ok, err := s.IsHealthy(context.Background())
+		if err != nil || !ok {
+			t.Fatalf("IsHealthy() = %v, %v; want true, nil", ok, err)
+		}
+	})
+
+	t.Run("unhealthy when uptime is not 1 (custom filter)", func(t *testing.T) {
+		srv := promServer(t, 200, okVal("0"))
+		s := plainScaler(srv.URL)
+		s.cooldownPeriod = time.Minute
+		s.metadata.UptimeFilter = `job="prometheus"`
+		ok, err := s.IsHealthy(context.Background())
+		if err != nil || ok {
+			t.Fatalf("IsHealthy() = %v, %v; want false, nil", ok, err)
+		}
+	})
+
+	t.Run("query error", func(t *testing.T) {
+		srv := promServer(t, 500, "")
+		s := plainScaler(srv.URL)
+		s.cooldownPeriod = time.Minute
+		if _, err := s.IsHealthy(context.Background()); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestClose(t *testing.T) {
+	if err := (&prometheusScaler{httpClient: &http.Client{}}).Close(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := (&prometheusScaler{}).Close(context.Background()); err != nil {
+		t.Fatalf("unexpected error with nil client: %v", err)
 	}
 }

--- a/pkg/scaling/scalers/prometheus_scaler_test.go
+++ b/pkg/scaling/scalers/prometheus_scaler_test.go
@@ -18,7 +18,6 @@ func TestIsBlockedIP(t *testing.T) {
 		{name: "IPv4 loopback", ip: "127.0.0.1", blocked: true},
 		{name: "IPv6 loopback", ip: "::1", blocked: true},
 		{name: "unspecified", ip: "0.0.0.0", blocked: true},
-		{name: "IPv4 cloud metadata", ip: "169.254.169.254", blocked: true},
 		{name: "IPv4 link-local", ip: "169.254.10.20", blocked: true},
 		{name: "IPv6 link-local", ip: "fe80::1", blocked: true},
 		{name: "multicast", ip: "224.0.0.1", blocked: true},
@@ -133,8 +132,8 @@ func TestResolveServerAddress(t *testing.T) {
 	}
 }
 
-func TestExecutePromQueryDefaultHeaderWins(t *testing.T) {
-	// The operator default Authorization header must win over a CRD-supplied one.
+func TestExecutePromQueryCRDHeaderWins(t *testing.T) {
+	// A per-trigger (CRD) header must override the operator default.
 	gotAuth := make(chan string, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth <- r.Header.Get("Authorization")
@@ -157,7 +156,7 @@ func TestExecutePromQueryDefaultHeaderWins(t *testing.T) {
 	if _, err := s.executePromQuery(context.Background(), "up"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if auth := <-gotAuth; auth != "operator-token" {
-		t.Errorf("Authorization header = %q, want operator default to win", auth)
+	if auth := <-gotAuth; auth != "crd-token" {
+		t.Errorf("Authorization header = %q, want per-trigger CRD header to win", auth)
 	}
 }

--- a/pkg/scaling/scalers/prometheus_scaler_test.go
+++ b/pkg/scaling/scalers/prometheus_scaler_test.go
@@ -128,25 +128,26 @@ func TestGetServerAddress(t *testing.T) {
 
 func TestValidateServerAddress(t *testing.T) {
 	tests := []struct {
-		name         string
-		metadataAddr string
-		allowed      []string
-		wantErr      bool
+		name        string
+		addr        string
+		defaultAddr string
+		allowed     []string
+		wantErr     bool
 	}{
-		{name: "no crd override is a no-op", allowed: []string{"prom.monitoring"}},
-		{name: "empty allowlist accepts any", metadataAddr: "http://anything:9090"},
-		{name: "host match", metadataAddr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring"}},
-		{name: "host:port match", metadataAddr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring:9090"}},
-		{name: "rejects unlisted host", metadataAddr: "http://request-catcher.evil:9090", allowed: []string{"prom.monitoring"}, wantErr: true},
+		{name: "empty allowlist accepts any", addr: "http://anything:9090"},
+		{name: "host match", addr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring"}},
+		{name: "host:port match", addr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring:9090"}},
+		{name: "rejects unlisted host", addr: "http://request-catcher.evil:9090", allowed: []string{"prom.monitoring"}, wantErr: true},
+		{name: "default is allowed despite non-matching allowlist", addr: "http://d:9090", defaultAddr: "http://d:9090", allowed: []string{"prom.monitoring"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &prometheusScaler{
-				metadata:               &prometheusMetadata{ServerAddress: tt.metadataAddr},
+				defaultServerAddress:   tt.defaultAddr,
 				allowedServerAddresses: tt.allowed,
 			}
-			err := s.validateServerAddress()
+			err := s.validateServerAddress(tt.addr)
 			if tt.wantErr && err == nil {
 				t.Fatal("expected error, got nil")
 			}

--- a/pkg/scaling/scalers/prometheus_scaler_test.go
+++ b/pkg/scaling/scalers/prometheus_scaler_test.go
@@ -90,32 +90,26 @@ func TestNewSafeHTTPClientRejectsRedirects(t *testing.T) {
 	}
 }
 
-func TestResolveServerAddress(t *testing.T) {
+func TestGetServerAddress(t *testing.T) {
 	tests := []struct {
 		name         string
 		metadataAddr string
 		defaultAddr  string
-		allowed      []string
 		want         string
 		wantErr      bool
 	}{
 		{name: "crd overrides default", metadataAddr: "http://prom.monitoring:9090", defaultAddr: "http://d:9090", want: "http://prom.monitoring:9090"},
 		{name: "falls back to default", defaultAddr: "http://d:9090", want: "http://d:9090"},
 		{name: "nothing configured errors", wantErr: true},
-		{name: "allowlist host match", metadataAddr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring"}, want: "http://prom.monitoring:9090"},
-		{name: "allowlist host:port match", metadataAddr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring:9090"}, want: "http://prom.monitoring:9090"},
-		{name: "allowlist rejects unlisted host", metadataAddr: "http://request-catcher.evil:9090", allowed: []string{"prom.monitoring"}, wantErr: true},
-		{name: "empty allowlist accepts any", metadataAddr: "http://anything:9090", want: "http://anything:9090"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &prometheusScaler{
-				metadata:               &prometheusMetadata{ServerAddress: tt.metadataAddr},
-				defaultServerAddress:   tt.defaultAddr,
-				allowedServerAddresses: tt.allowed,
+				metadata:             &prometheusMetadata{ServerAddress: tt.metadataAddr},
+				defaultServerAddress: tt.defaultAddr,
 			}
-			got, err := s.resolveServerAddress()
+			got, err := s.getServerAddress()
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got address %q", got)
@@ -126,7 +120,38 @@ func TestResolveServerAddress(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 			if got != tt.want {
-				t.Errorf("resolveServerAddress() = %q, want %q", got, tt.want)
+				t.Errorf("getServerAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateServerAddress(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadataAddr string
+		allowed      []string
+		wantErr      bool
+	}{
+		{name: "no crd override is a no-op", allowed: []string{"prom.monitoring"}},
+		{name: "empty allowlist accepts any", metadataAddr: "http://anything:9090"},
+		{name: "host match", metadataAddr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring"}},
+		{name: "host:port match", metadataAddr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring:9090"}},
+		{name: "rejects unlisted host", metadataAddr: "http://request-catcher.evil:9090", allowed: []string{"prom.monitoring"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &prometheusScaler{
+				metadata:               &prometheusMetadata{ServerAddress: tt.metadataAddr},
+				allowedServerAddresses: tt.allowed,
+			}
+			err := s.validateServerAddress()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/pkg/scaling/scalers/prometheus_scaler_test.go
+++ b/pkg/scaling/scalers/prometheus_scaler_test.go
@@ -1,0 +1,163 @@
+package scalers
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestIsBlockedIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		blocked bool
+	}{
+		{name: "IPv4 loopback", ip: "127.0.0.1", blocked: true},
+		{name: "IPv6 loopback", ip: "::1", blocked: true},
+		{name: "unspecified", ip: "0.0.0.0", blocked: true},
+		{name: "IPv4 cloud metadata", ip: "169.254.169.254", blocked: true},
+		{name: "IPv4 link-local", ip: "169.254.10.20", blocked: true},
+		{name: "IPv6 link-local", ip: "fe80::1", blocked: true},
+		{name: "multicast", ip: "224.0.0.1", blocked: true},
+		// Private ranges are allowed: in-cluster Prometheus lives on a ClusterIP.
+		{name: "private 10.x (ClusterIP)", ip: "10.96.0.10", blocked: false},
+		{name: "private 172.16.x", ip: "172.16.5.4", blocked: false},
+		{name: "private 192.168.x", ip: "192.168.1.1", blocked: false},
+		{name: "IPv6 ULA (in-cluster)", ip: "fd12:3456::1", blocked: false},
+		{name: "public IPv4", ip: "8.8.8.8", blocked: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("failed to parse test IP %q", tt.ip)
+			}
+			if got := isBlockedIP(ip); got != tt.blocked {
+				t.Errorf("isBlockedIP(%s) = %v, want %v", tt.ip, got, tt.blocked)
+			}
+		})
+	}
+}
+
+func TestNewSafeHTTPClientBlocksLoopback(t *testing.T) {
+	// A real listener on loopback: the dial guard must refuse to connect to it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := newHTTPClient(true)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	if _, err := client.Do(req); err == nil {
+		t.Fatal("expected connection to loopback to be blocked, got nil error")
+	}
+}
+
+func TestNewHTTPClientDialGuardDisabledAllowsLoopback(t *testing.T) {
+	// When an allowlist is configured (dialGuard=false), the allowlist is the
+	// sole gate, so an explicitly-allowed loopback target must be reachable.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := newHTTPClient(false)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("expected loopback to be reachable without dial guard, got %v", err)
+	}
+	defer resp.Body.Close()
+}
+
+func TestNewSafeHTTPClientRejectsRedirects(t *testing.T) {
+	client := newHTTPClient(true)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	if err := client.CheckRedirect(req, nil); err == nil {
+		t.Fatal("expected CheckRedirect to reject redirects, got nil error")
+	}
+}
+
+func TestResolveServerAddress(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadataAddr string
+		defaultAddr  string
+		allowed      []string
+		want         string
+		wantErr      bool
+	}{
+		{name: "crd overrides default", metadataAddr: "http://prom.monitoring:9090", defaultAddr: "http://d:9090", want: "http://prom.monitoring:9090"},
+		{name: "falls back to default", defaultAddr: "http://d:9090", want: "http://d:9090"},
+		{name: "nothing configured errors", wantErr: true},
+		{name: "allowlist host match", metadataAddr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring"}, want: "http://prom.monitoring:9090"},
+		{name: "allowlist host:port match", metadataAddr: "http://prom.monitoring:9090", allowed: []string{"prom.monitoring:9090"}, want: "http://prom.monitoring:9090"},
+		{name: "allowlist rejects unlisted host", metadataAddr: "http://request-catcher.evil:9090", allowed: []string{"prom.monitoring"}, wantErr: true},
+		{name: "empty allowlist accepts any", metadataAddr: "http://anything:9090", want: "http://anything:9090"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &prometheusScaler{
+				metadata:               &prometheusMetadata{ServerAddress: tt.metadataAddr},
+				defaultServerAddress:   tt.defaultAddr,
+				allowedServerAddresses: tt.allowed,
+			}
+			got, err := s.resolveServerAddress()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got address %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveServerAddress() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecutePromQueryDefaultHeaderWins(t *testing.T) {
+	// The operator default Authorization header must win over a CRD-supplied one.
+	gotAuth := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth <- r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{},"value":[1,"1"]}]}}`))
+	}))
+	defer srv.Close()
+
+	s := &prometheusScaler{
+		// httptest listens on loopback, so use a plain client here (the guard is
+		// covered by its own test); this test targets header precedence only.
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		metadata: &prometheusMetadata{
+			ServerAddress: srv.URL,
+			Headers:       map[string]string{"Authorization": "crd-token"},
+		},
+		defaultHeaders: map[string]string{"Authorization": "operator-token"},
+	}
+
+	if _, err := s.executePromQuery(context.Background(), "up"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if auth := <-gotAuth; auth != "operator-token" {
+		t.Errorf("Authorization header = %q, want operator default to win", auth)
+	}
+}


### PR DESCRIPTION
## Description
Hardens the Prometheus scaler against Server-Side Request Forgery (CWE-918). A namespace tenant with `ElastiService` create permission could set `triggers[].metadata.serverAddress` to any URL and make the cluster-privileged operator send an HTTP GET there (internal service access, Kubernetes API probing, cloud metadata service).

This was reported privately via `security@truefoundry.com` (tracked internally as AUT-147). Changes, all backward compatible when no allowlist is set:

- **Admin allowlist (opt-in, priority):** new optional `PROMETHEUS_TRIGGER_ALLOWED_SERVER_ADDRESSES` operator env var (Helm: `elastiController.manager.env.prometheusTriggerAllowedServerAddresses`) - a comma-separated list of allowed Prometheus hosts (`host` or `host:port`). When set, it is the sole gate on the destination: a CRD `serverAddress` must match, and an explicitly allowed host is reachable even if it would otherwise be blocked (allowlist beats blocklist).
- **Dial-time blocklist (fallback):** when no allowlist is configured, outbound requests are refused at dial time (after DNS resolution, so hostname- and redirect-based bypasses are covered) to loopback, unspecified, link-local (incl. IPv4 metadata `169.254.169.254`), and multicast addresses. Private ranges stay allowed - an in-cluster Prometheus is reached via a private ClusterIP / `*.svc.cluster.local`.
- **No redirects:** the scaler's HTTP client rejects all redirects (the Prometheus query API never issues them).
- **Header hardening:** a trigger's `metadata.headers` can no longer override an operator-configured default header (e.g. `Authorization`).

Fixes # (privately reported, CWE-918 / AUT-147)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] `go test ./pkg/scaling/scalers/...` - new unit tests: IP blocklist matrix (metadata/loopback/link-local blocked, private/public allowed), dial guard blocks loopback, allowlist disables the guard for an allowed host, redirects rejected, allowlist host / host:port resolution, and operator default `Authorization` header wins over CRD.
- [x] `go build ./...` and `go vet ./...` (pkg + operator).
- [x] `helm template charts/elasti ...` renders the new env when set and omits it when unset.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] A PR is open to update the helm chart (link)[https://github.com/KubeElasti/KubeElasti/tree/main/charts/elasti] if applicable (chart change included in this PR)
- [x] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made
