### PR TITLE
fix: pin build & release dependencies by hash (Scorecard Pinned-Dependencies)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Keep pinned GitHub Actions SHAs fresh
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+
+  # Keep pinned base-image digests fresh
+  - package-ecosystem: docker
+    directories:
+      - /operator
+      - /resolver
+      - /tests/e2e/grpc-test-service
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "build"
+
+  # Go module dependencies (three modules stitched by go.work)
+  - package-ecosystem: gomod
+    directories:
+      - /operator
+      - /resolver
+      - /pkg
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"

--- a/.github/workflows/build-n-publish.yml
+++ b/.github/workflows/build-n-publish.yml
@@ -48,7 +48,7 @@ jobs:
     needs: [build-operator, build-resolver]
     steps:
       - name: Checkout helm-main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: "0"
           ref: helm-main

--- a/.github/workflows/codescan.yaml
+++ b/.github/workflows/codescan.yaml
@@ -71,20 +71,20 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       # Must match go.work / module toolchain so `go list` and CodeQL extraction succeed.
       # Without this, autobuild uses the runner default Go (e.g. 1.24) and fails with:
       #   go.work requires go >= 1.25.9 (running go 1.24.x)
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.work
           cache: true
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -112,6 +112,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -35,11 +35,11 @@ jobs:
           - module: pkg
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: "0"
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -49,7 +49,7 @@ jobs:
       - name: Run tests with coverage
         run: cd ${{ matrix.module }} && make test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.module }}/cover.out

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -21,18 +21,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.x
-      - run: pip install zensical
+      - run: pip install zensical==0.0.51
       - name: Fetch contributors
         run: python docs/assets/scripts/fetch_contributors.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: zensical build --clean
       - name: Push site to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/e2e-kuttl-test.yaml
+++ b/.github/workflows/e2e-kuttl-test.yaml
@@ -25,19 +25,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
         with:
           go-version: "1.23"
           cache: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
           version: 'v3.12.3'
 
@@ -47,7 +47,7 @@ jobs:
           make build-images
       
       - name: Install Kind
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           install_only: true
 

--- a/.github/workflows/first-interaction-greeting.yml
+++ b/.github/workflows/first-interaction-greeting.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Greet contributor
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_MESSAGE: |
             👋 Welcome to the KubeElasti community! 💖

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-index-generation.yml
+++ b/.github/workflows/helm-index-generation.yml
@@ -17,13 +17,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: 'v4.0.4'
 

--- a/.github/workflows/helm-readme-generator.yml
+++ b/.github/workflows/helm-readme-generator.yml
@@ -17,9 +17,9 @@ jobs:
       contents: write
     steps:
       - name: Install readme-generator-for-helm
-        run: npm install -g @bitnami/readme-generator-for-helm
+        run: npm install -g @bitnami/readme-generator-for-helm@2.7.2
       - name: Checkout charts
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -29,8 +29,8 @@ jobs:
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - id: set-modules
@@ -44,11 +44,11 @@ jobs:
         modules: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: "0"
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -56,7 +56,7 @@ jobs:
         run: go mod tidy
         working-directory: ${{ matrix.modules }}
       - name: golangci-lint ${{ matrix.modules }}
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
         with:
           working-directory: ${{ matrix.modules }}
           args: -v --timeout 5m
@@ -69,11 +69,11 @@ jobs:
         modules: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: "0"
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       operator_tag: ${{ steps.read_chart.outputs.OPERATOR_TAG }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: "0"
 
@@ -104,18 +104,18 @@ jobs:
       id-token: write # required for keyless cosign signing of the chart
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: "0"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       # cosign reads Docker's credential store (~/.docker/config.json), which
       # `helm registry login` does not populate. Log in with Docker so cosign can
       # pull the pushed chart to sign it.
       - name: Log in to GHCR (for cosign)
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -161,7 +161,7 @@ jobs:
           cosign sign --yes "${CHART_REF}"
 
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         id: syft
 
       - name: Generate Helm chart SBOM
@@ -195,19 +195,19 @@ jobs:
           done
 
       - name: Download operator image SBOM and signatures
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ needs.build-operator.outputs.sbom_artifact_name }}
           path: image-sboms
 
       - name: Download resolver image SBOM and signatures
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ needs.build-resolver.outputs.sbom_artifact_name }}
           path: image-sboms
 
       - name: Upload Helm chart, SBOMs and signatures to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
             # Chart .tgz + chart SBOM + their .sigstore.json bundles, plus the
             # per-image SBOMs and cosign signature files (.sig/.pem/.payload/.sigstore.json).

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'truefoundry/elasti'
     name: Stale issue bot
     steps:
-      - uses: actions/stale@v9.0.0
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has been inactive for 90 days. StaleBot will close this stale issue after 180 more days of inactivity.'

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o manag
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/resolver/Dockerfile
+++ b/resolver/Dockerfile
@@ -1,5 +1,5 @@
 # Build the resolver bianry
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -o resol
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 WORKDIR /
 COPY --from=builder /workspace/resolver .
 USER 65532:65532

--- a/tests/e2e/grpc-test-service/Dockerfile
+++ b/tests/e2e/grpc-test-service/Dockerfile
@@ -2,7 +2,7 @@
 # NOTE: golang:1.25.9 matches the project-wide Go toolchain version used in
 # operator/Dockerfile and resolver/Dockerfile. If building outside CI, ensure
 # this image is available in your registry or pin to a released version.
-FROM golang:1.26.5 AS builder
+FROM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /grpc-server ./server/
 RUN CGO_ENABLED=0 GOOS=linux go build -o /grpc-client ./client/
 
 # Use distroless as minimal base image
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 WORKDIR /
 COPY --from=builder /grpc-server .
 COPY --from=builder /grpc-client .


### PR DESCRIPTION
## Description
Resolves all 45 open OSSF Scorecard **Pinned-Dependencies** code-scanning alerts (rule `PinnedDependenciesID`, e.g. [#105](https://github.com/KubeElasti/KubeElasti/security/code-scanning/105)). Every alert had the same root cause: a build/release dependency referenced by a mutable tag instead of an immutable hash, which leaves the build open to a supply-chain compromise if an upstream tag is moved.

Changes:
- **GitHub Actions (12 workflows)** - pinned every flagged `uses:` to a full 40-char commit SHA with a `# <version>` comment, matching the format already used in `scorecard.yml` (e.g. `codecov/codecov-action@0fb7174... # v5.5.5`).
- **Container images (3 Dockerfiles)** - pinned `golang:1.26.5` and `gcr.io/distroless/static:nonroot` to their multi-arch manifest-list `@sha256:` digests, keeping the tag inline so the version stays readable.
- **Package installs** - pinned `@bitnami/readme-generator-for-helm@2.7.2` (npm) and `zensical==0.0.51` (pip).
- **New `.github/dependabot.yml`** - weekly updates for `github-actions`, `docker`, and `gomod` so the pins don't go stale (Scorecard's own recommended remediation).

The `truefoundry/github-workflows-public/...@main` reusable-workflow refs are intentionally left tracking `@main` (Scorecard does not flag them).

Fixes the Pinned-Dependencies alerts under https://github.com/KubeElasti/KubeElasti/security/code-scanning

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Confirmed no mutable action refs remain (`grep` for `uses:` without a 40-char SHA returns only the intentional `@main` reusable workflows)
- [x] Confirmed all 6 Dockerfile `FROM` lines carry a `@sha256:` digest, and both base-image digests are multi-arch manifest lists covering linux/amd64 + linux/arm64
- [x] Validated all changed workflow YAML files and `dependabot.yml` parse cleanly
- [ ] Final confirmation on merge: the 45 Pinned-Dependencies alerts auto-close after the next scheduled Scorecard run against `main`

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] A PR is open to update the helm chart (link)[https://github.com/KubeElasti/KubeElasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made
