### PR TITLE
fix: insufficient Host header validation in resolver (CWE-200)

### DIFF
--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -93,9 +93,9 @@ func main() {
 	// Get components required for the handler
 	k8sUtil := k8shelper.NewOps(logger, config)
 	newOperatorRPC := operator.NewOperatorClient(logger, time.Duration(env.OperatorRetryDuration)*time.Second)
-	newHostManager := hostmanager.NewHostManager(logger, time.Duration(env.TrafficReEnableDuration)*time.Second, time.Duration(env.TrafficDisableGraceDuration)*time.Second, env.HeaderForHost)
 	crdCache := crdcache.New(logger, newOperatorRPC, time.Duration(env.CRDCachePollIntervalMinutes)*time.Minute)
 	crdCache.StartBackground()
+	newHostManager := hostmanager.NewHostManager(logger, time.Duration(env.TrafficReEnableDuration)*time.Second, time.Duration(env.TrafficDisableGraceDuration)*time.Second, env.HeaderForHost, crdCache)
 	newTransport := throttler.NewProxyAutoTransport(env.MaxIdleProxyConns, env.MaxIdleProxyConnsPerHost)
 	newThrottler := throttler.NewThrottler(&throttler.Params{
 		QueueRetryDuration:      time.Duration(env.QueueRetryDuration) * time.Second,

--- a/resolver/internal/crdcache/cache.go
+++ b/resolver/internal/crdcache/cache.go
@@ -13,13 +13,22 @@ import (
 
 const defaultPollInterval = 5 * time.Minute
 
+// minOnDemandRefreshInterval bounds how often a cache miss may trigger a synchronous refresh
+// from the operator. It lets a newly-created ElastiService be picked up on its first request
+// (instead of waiting for the next poll) while preventing probing for unknown hosts from
+// turning into an operator fetch storm.
+const minOnDemandRefreshInterval = 2 * time.Second
+
 type Cache struct {
 	logger       *zap.Logger
 	operatorRPC  *operator.Client
 	pollInterval time.Duration
 
-	mu    sync.RWMutex
-	cache *sync.Map // key: "namespace/service-name", value: *messages.ElastiServiceEntry
+	mu        sync.RWMutex
+	cache     *sync.Map // key: "namespace/service-name", value: *messages.ElastiServiceEntry
+	lastFetch time.Time // time of the last successful fetch (poll or on-demand); guarded by mu
+
+	refreshMu sync.Mutex // serializes on-demand refreshes triggered by GetElastiServiceFresh
 
 	stopCh   chan struct{}
 	stopOnce sync.Once
@@ -83,6 +92,7 @@ func (c *Cache) fetch() error {
 
 	c.mu.Lock()
 	c.cache = newCache
+	c.lastFetch = time.Now()
 	c.mu.Unlock()
 
 	c.logger.Debug("ElastiService cache updated", zap.Int("count", len(resp.Services)))
@@ -100,6 +110,35 @@ func (c *Cache) GetElastiService(namespacedServiceName string) (*messages.Elasti
 		return nil, false
 	}
 	return val.(*messages.ElastiServiceEntry), true
+}
+
+// GetElastiServiceFresh returns the entry for "namespace/service-name". On a miss it triggers
+// a rate-limited synchronous refresh from the operator and re-checks, so an ElastiService
+// created since the last poll is recognized on its first request rather than being rejected
+// until the next poll interval. The refresh is throttled by minOnDemandRefreshInterval so
+// requests for unknown hosts cannot flood the operator with fetches.
+func (c *Cache) GetElastiServiceFresh(namespacedServiceName string) (*messages.ElastiServiceEntry, bool) {
+	if entry, ok := c.GetElastiService(namespacedServiceName); ok {
+		return entry, true
+	}
+	c.refreshOnDemand()
+	return c.GetElastiService(namespacedServiceName)
+}
+
+// refreshOnDemand fetches from the operator at most once per minOnDemandRefreshInterval.
+func (c *Cache) refreshOnDemand() {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+
+	c.mu.RLock()
+	since := time.Since(c.lastFetch)
+	c.mu.RUnlock()
+	if since < minOnDemandRefreshInterval {
+		return
+	}
+	if err := c.fetch(); err != nil {
+		c.logger.Warn("on-demand ElastiService cache refresh failed", zap.Error(err))
+	}
 }
 
 // CachedService is one ElastiService in the resolver's local cache (key is namespace/service-name).

--- a/resolver/internal/crdcache/cache_test.go
+++ b/resolver/internal/crdcache/cache_test.go
@@ -125,6 +125,57 @@ func TestGetElastiServiceMiss(t *testing.T) {
 	}
 }
 
+// TestGetElastiServiceFreshRefreshesOnMiss checks that a miss triggers an on-demand refresh,
+// so a service registered since the last poll is found without waiting for the next poll.
+func TestGetElastiServiceFreshRefreshesOnMiss(t *testing.T) {
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		respondWith(&messages.ElastiServiceCacheResponse{
+			Services: map[string]messages.ElastiServiceEntry{"ns/svc": {Name: "es"}},
+		})(w, r)
+	}))
+	defer srv.Close()
+
+	c := newTestCache(t, srv, time.Minute)
+
+	// Nothing fetched yet: a plain get misses.
+	if _, ok := c.GetElastiService("ns/svc"); ok {
+		t.Fatal("expected miss before any fetch")
+	}
+	// The Fresh variant refreshes on the miss and finds it.
+	if _, ok := c.GetElastiServiceFresh("ns/svc"); !ok {
+		t.Fatal("expected GetElastiServiceFresh to find service after on-demand refresh")
+	}
+	if calls.Load() == 0 {
+		t.Fatal("expected on-demand refresh to reach the operator")
+	}
+}
+
+// TestGetElastiServiceFreshThrottlesRefresh checks that repeated misses inside the throttle
+// window trigger only a single operator fetch, so probing for unknown hosts can't flood it.
+func TestGetElastiServiceFreshThrottlesRefresh(t *testing.T) {
+	var calls atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		respondWith(&messages.ElastiServiceCacheResponse{
+			Services: map[string]messages.ElastiServiceEntry{},
+		})(w, r)
+	}))
+	defer srv.Close()
+
+	c := newTestCache(t, srv, time.Minute)
+
+	for i := 0; i < 5; i++ {
+		if _, ok := c.GetElastiServiceFresh("ns/unknown"); ok {
+			t.Fatal("expected miss for unknown key")
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 on-demand refresh within throttle window, got %d", got)
+	}
+}
+
 // TestConcurrentFetchAndGet exercises the RWMutex guarding the cache pointer.
 func TestConcurrentFetchAndGet(t *testing.T) {
 	srv := httptest.NewServer(respondWith(&messages.ElastiServiceCacheResponse{

--- a/resolver/internal/crdcache/spec_test.go
+++ b/resolver/internal/crdcache/spec_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/truefoundry/elasti/operator/api/v1alpha1"
 	"github.com/stretchr/testify/require"
+	"github.com/truefoundry/elasti/operator/api/v1alpha1"
 	"go.uber.org/zap"
 )
 

--- a/resolver/internal/handler/handler.go
+++ b/resolver/internal/handler/handler.go
@@ -93,11 +93,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	prom.IncomingRequestHistogram.WithLabelValues(
 		host.SourceService,
 		host.TargetService,
-		host.SourceHost,
-		host.TargetHost,
 		host.Namespace,
 		req.Method,
-		req.RequestURI,
 		responseStatus,
 		errorMessage,
 	).Observe(duration)

--- a/resolver/internal/hostmanager/hostManager.go
+++ b/resolver/internal/hostmanager/hostManager.go
@@ -20,9 +20,10 @@ import (
 // ElastiServiceChecker reports whether an ElastiService CR exists for a given
 // "namespace/service" key. It is satisfied by the resolver's crdcache.Cache and lets the
 // HostManager reject Host headers that don't map to a real ElastiService before they are
-// cached, proxied, or exported as metrics.
+// cached, proxied, or exported as metrics. The Fresh variant refreshes from the operator on
+// a miss (rate-limited) so a newly-created ElastiService is recognized on its first request.
 type ElastiServiceChecker interface {
-	GetElastiService(namespacedServiceName string) (*messages.ElastiServiceEntry, bool)
+	GetElastiServiceFresh(namespacedServiceName string) (*messages.ElastiServiceEntry, bool)
 }
 
 // HostManager is to manage the hosts, and their traffic
@@ -74,7 +75,7 @@ func (hm *HostManager) GetHost(req *http.Request) (*messages.Host, error) {
 		// unauthenticated caller could make the resolver cache, proxy to, and probe
 		// arbitrary in-cluster services across namespaces (CWE-200 / cross-namespace SSRF).
 		if hm.crdChecker != nil {
-			if _, exists := hm.crdChecker.GetElastiService(namespace + "/" + sourceService); !exists {
+			if _, exists := hm.crdChecker.GetElastiServiceFresh(namespace + "/" + sourceService); !exists {
 				prom.HostExtractionCounter.WithLabelValues("rejected", "unknown-service").Inc()
 				return &messages.Host{}, fmt.Errorf("no ElastiService registered for host: %s", logger.MaskMiddle(incomingHost, 4, 4))
 			}

--- a/resolver/internal/hostmanager/hostManager.go
+++ b/resolver/internal/hostmanager/hostManager.go
@@ -17,6 +17,14 @@ import (
 	"go.uber.org/zap"
 )
 
+// ElastiServiceChecker reports whether an ElastiService CR exists for a given
+// "namespace/service" key. It is satisfied by the resolver's crdcache.Cache and lets the
+// HostManager reject Host headers that don't map to a real ElastiService before they are
+// cached, proxied, or exported as metrics.
+type ElastiServiceChecker interface {
+	GetElastiService(namespacedServiceName string) (*messages.ElastiServiceEntry, bool)
+}
+
 // HostManager is to manage the hosts, and their traffic
 // It is used to process incoming requests and cache the host details in "hosts" map
 // For further requests, the cache is used to get the host details
@@ -26,16 +34,20 @@ type HostManager struct {
 	trafficReEnableDuration     time.Duration
 	trafficDisableGraceDuration time.Duration
 	headerForHost               string
+	crdChecker                  ElastiServiceChecker
 }
 
-// NewHostManager returns a new HostManager
-func NewHostManager(logger *zap.Logger, trafficReEnableDuration, trafficDisableGraceDuration time.Duration, headerForHost string) *HostManager {
+// NewHostManager returns a new HostManager.
+// crdChecker validates that a parsed (namespace, service) belongs to a known ElastiService;
+// pass nil to disable that check (used in tests).
+func NewHostManager(logger *zap.Logger, trafficReEnableDuration, trafficDisableGraceDuration time.Duration, headerForHost string, crdChecker ElastiServiceChecker) *HostManager {
 	return &HostManager{
 		logger:                      logger.With(zap.String("component", "hostManager")),
 		hosts:                       sync.Map{},
 		trafficReEnableDuration:     trafficReEnableDuration,
 		trafficDisableGraceDuration: trafficDisableGraceDuration,
 		headerForHost:               headerForHost,
+		crdChecker:                  crdChecker,
 	}
 }
 
@@ -45,17 +57,30 @@ func (hm *HostManager) GetHost(req *http.Request) (*messages.Host, error) {
 	if values, ok := req.Header[hm.headerForHost]; ok {
 		incomingHost = values[0]
 	}
+	// Normalize the key by dropping the request path/wildcard (the actual path is taken from
+	// req.RequestURI at proxy time). This collapses the otherwise-unbounded set of path
+	// variations for a given host:port into a single cache entry, so a caller cannot grow
+	// hm.hosts without bound by sending many distinct paths for the same service.
+	incomingHost = hm.removeTrailingWildcardIfNeeded(incomingHost)
+	incomingHost = hm.removeTrailingPathIfNeeded(incomingHost)
 	host, ok := hm.hosts.Load(incomingHost)
 	if !ok {
 		sourceService, namespace, err := hm.extractNamespaceAndService(incomingHost)
 		if err != nil {
-			prom.HostExtractionCounter.WithLabelValues("error", incomingHost, hm.headerForHost, err.Error()).Inc()
+			prom.HostExtractionCounter.WithLabelValues("error", "invalid-format").Inc()
 			return &messages.Host{}, err
 		}
+		// Reject Host headers that don't map to a known ElastiService. Without this an
+		// unauthenticated caller could make the resolver cache, proxy to, and probe
+		// arbitrary in-cluster services across namespaces (CWE-200 / cross-namespace SSRF).
+		if hm.crdChecker != nil {
+			if _, exists := hm.crdChecker.GetElastiService(namespace + "/" + sourceService); !exists {
+				prom.HostExtractionCounter.WithLabelValues("rejected", "unknown-service").Inc()
+				return &messages.Host{}, fmt.Errorf("no ElastiService registered for host: %s", logger.MaskMiddle(incomingHost, 4, 4))
+			}
+		}
 		targetService := utils.GetPrivateServiceName(sourceService)
-		sourceHost := hm.removeTrailingWildcardIfNeeded(incomingHost)
-		sourceHost = hm.removeTrailingPathIfNeeded(sourceHost)
-		sourceHost = hm.addHTTPIfNeeded(sourceHost)
+		sourceHost := hm.addHTTPIfNeeded(incomingHost)
 		targetHost := hm.replaceServiceName(sourceHost, targetService)
 		targetHost = hm.addHTTPIfNeeded(targetHost)
 		newHost := &messages.Host{
@@ -68,10 +93,10 @@ func (hm *HostManager) GetHost(req *http.Request) (*messages.Host, error) {
 			TrafficAllowed: true,
 		}
 		hm.hosts.Store(incomingHost, newHost)
-		prom.HostExtractionCounter.WithLabelValues("cache-miss", incomingHost, hm.headerForHost, "").Inc()
+		prom.HostExtractionCounter.WithLabelValues("cache-miss", "").Inc()
 		return newHost, nil
 	}
-	prom.HostExtractionCounter.WithLabelValues("cache-hit", incomingHost, hm.headerForHost, "").Inc()
+	prom.HostExtractionCounter.WithLabelValues("cache-hit", "").Inc()
 	return host.(*messages.Host), nil
 }
 
@@ -129,41 +154,38 @@ func (hm *HostManager) enableTrafficForHost(hostName string) {
 	}
 }
 
-func (hm *HostManager) extractNamespaceAndService(url string) (string, string, error) {
-	// Define regular expression patterns for different Kubernetes internal URL formats
-	patterns := []string{
-		`http://([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.svc\.cluster\.local:\d+/\*`,
-		`([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.svc\.cluster\.local:\d+/\*`,
-		`http://([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.svc\.cluster\.local:\d+`,
-		`([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.svc\.cluster\.local:\d+`,
-		`http://([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.svc\.cluster\.local`,
-		`([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.svc\.cluster\.local`,
-		`http://([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.svc`,
-		`([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.svc`,
-		`http://([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)`,
-		`([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)`,
-		`http://([a-zA-Z0-9-]+)\.svc\.cluster\.local`,
-		`([a-zA-Z0-9-]+)\.svc\.cluster\.local`,
-		`http://([a-zA-Z0-9-]+)\.svc`,
-		`([a-zA-Z0-9-]+)\.svc`,
-		`http://([a-zA-Z0-9-]+)`,
-		`([a-zA-Z0-9-]+)`,
+// k8sServiceHostRe matches only the Kubernetes service DNS forms
+// "<service>.<namespace>.svc" and "<service>.<namespace>.svc.cluster.local", where each
+// of <service> and <namespace> is a valid RFC 1123 DNS label. The previous catch-all
+// patterns accepted any two-segment or single-segment string, which let attackers inject
+// arbitrary Host headers (CWE-200); those are intentionally gone.
+var k8sServiceHostRe = regexp.MustCompile(
+	`^([a-z0-9]([-a-z0-9]*[a-z0-9])?)\.([a-z0-9]([-a-z0-9]*[a-z0-9])?)\.svc(?:\.cluster\.local)?$`,
+)
+
+// maxDNSLabelLength is the RFC 1123 limit for a single DNS label (service/namespace name).
+const maxDNSLabelLength = 63
+
+func (hm *HostManager) extractNamespaceAndService(rawHost string) (string, string, error) {
+	// Strip scheme, path/wildcard, and port so only the DNS name remains.
+	host := strings.TrimPrefix(rawHost, "http://")
+	host = strings.TrimPrefix(host, "https://")
+	if idx := strings.IndexByte(host, '/'); idx != -1 {
+		host = host[:idx]
 	}
-	var serviceName, namespace string
-	for _, pattern := range patterns {
-		re := regexp.MustCompile(pattern)
-		matches := re.FindStringSubmatch(url)
-		if len(matches) == 3 {
-			serviceName = matches[1]
-			namespace = matches[2]
-			return serviceName, namespace, nil
-		} else if len(matches) == 2 {
-			serviceName = matches[1]
-			namespace = "default"
-			return serviceName, namespace, fmt.Errorf("namespace not found in URL: %s", logger.MaskMiddle(url, 4, 4))
-		}
+	if idx := strings.LastIndexByte(host, ':'); idx != -1 {
+		host = host[:idx]
 	}
-	return "", "", fmt.Errorf("invalid Kubernetes URL: %s", logger.MaskMiddle(url, 4, 4))
+
+	matches := k8sServiceHostRe.FindStringSubmatch(host)
+	if matches == nil {
+		return "", "", fmt.Errorf("invalid Kubernetes service host: %s", logger.MaskMiddle(rawHost, 4, 4))
+	}
+	serviceName, namespace := matches[1], matches[3]
+	if len(serviceName) > maxDNSLabelLength || len(namespace) > maxDNSLabelLength {
+		return "", "", fmt.Errorf("invalid Kubernetes service host: %s", logger.MaskMiddle(rawHost, 4, 4))
+	}
+	return serviceName, namespace, nil
 }
 
 // addHTTPIfNeeded adds http if not present in the service URL

--- a/resolver/internal/hostmanager/hostManager_test.go
+++ b/resolver/internal/hostmanager/hostManager_test.go
@@ -15,7 +15,7 @@ type fakeChecker struct {
 	known map[string]bool
 }
 
-func (f *fakeChecker) GetElastiService(key string) (*messages.ElastiServiceEntry, bool) {
+func (f *fakeChecker) GetElastiServiceFresh(key string) (*messages.ElastiServiceEntry, bool) {
 	if f.known[key] {
 		return &messages.ElastiServiceEntry{Name: key}, true
 	}

--- a/resolver/internal/hostmanager/hostManager_test.go
+++ b/resolver/internal/hostmanager/hostManager_test.go
@@ -10,9 +10,20 @@ import (
 	"go.uber.org/zap"
 )
 
+// fakeChecker implements ElastiServiceChecker over a fixed set of "namespace/service" keys.
+type fakeChecker struct {
+	known map[string]bool
+}
+
+func (f *fakeChecker) GetElastiService(key string) (*messages.ElastiServiceEntry, bool) {
+	if f.known[key] {
+		return &messages.ElastiServiceEntry{Name: key}, true
+	}
+	return nil, false
+}
+
 func TestGetHost(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	hm := NewHostManager(logger, 10*time.Second, 15*time.Second, "X-Envoy-Decorator-Operation")
 
 	tests := []struct {
 		name          string
@@ -29,7 +40,7 @@ func TestGetHost(t *testing.T) {
 				},
 			},
 			expectedHost: &messages.Host{
-				IncomingHost:   "service.namespace.svc.cluster.local:8080/test/*",
+				IncomingHost:   "service.namespace.svc.cluster.local:8080",
 				Namespace:      "namespace",
 				SourceService:  "service",
 				TargetService:  "elasti-service-pvt-9df6b026a8",
@@ -43,6 +54,7 @@ func TestGetHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			hm := NewHostManager(logger, 10*time.Second, 15*time.Second, "X-Envoy-Decorator-Operation", nil)
 			host, err := hm.GetHost(tt.req)
 			if tt.expectedError {
 				assert.Error(t, err)
@@ -52,4 +64,81 @@ func TestGetHost(t *testing.T) {
 			assert.Equal(t, tt.expectedHost, host)
 		})
 	}
+}
+
+// TestExtractNamespaceAndService asserts only strict k8s service DNS forms are accepted and
+// the previous catch-all patterns (arbitrary two-/single-segment hosts) are rejected.
+func TestExtractNamespaceAndService(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	hm := NewHostManager(logger, 10*time.Second, 15*time.Second, "Host", nil)
+
+	tests := []struct {
+		name      string
+		input     string
+		wantSvc   string
+		wantNs    string
+		wantError bool
+	}{
+		{name: "fqdn with port and path", input: "svc.ns.svc.cluster.local:8080/x/*", wantSvc: "svc", wantNs: "ns"},
+		{name: "fqdn no port", input: "svc.ns.svc.cluster.local", wantSvc: "svc", wantNs: "ns"},
+		{name: "short svc form", input: "svc.ns.svc", wantSvc: "svc", wantNs: "ns"},
+		{name: "with http scheme", input: "http://svc.ns.svc.cluster.local:8080", wantSvc: "svc", wantNs: "ns"},
+		{name: "hyphenated labels", input: "my-svc.my-ns.svc.cluster.local", wantSvc: "my-svc", wantNs: "my-ns"},
+
+		// The vulnerable catch-all cases must now be rejected.
+		{name: "arbitrary two-segment", input: "malicious.attacker", wantError: true},
+		{name: "single segment", input: "evil-service", wantError: true},
+		{name: "two segment with port", input: "malicious.attacker:8012", wantError: true},
+		{name: "real cluster svc without elastisvc still parses format", input: "kube-dns.kube-system.svc.cluster.local", wantSvc: "kube-dns", wantNs: "kube-system"},
+		{name: "missing svc segment", input: "svc.ns.cluster.local", wantError: true},
+		{name: "empty", input: "", wantError: true},
+		{name: "uppercase rejected", input: "Svc.Ns.svc.cluster.local", wantError: true},
+		{name: "trailing dot label", input: "svc-.ns.svc", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, ns, err := hm.extractNamespaceAndService(tt.input)
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantSvc, svc)
+			assert.Equal(t, tt.wantNs, ns)
+		})
+	}
+}
+
+// TestGetHostRejectsUnknownService asserts that a well-formed host is still rejected when no
+// matching ElastiService exists, blocking cross-namespace probing / SSRF via the resolver.
+func TestGetHostRejectsUnknownService(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	checker := &fakeChecker{known: map[string]bool{"namespace/service": true}}
+	hm := NewHostManager(logger, 10*time.Second, 15*time.Second, "Host", checker)
+
+	t.Run("known service accepted", func(t *testing.T) {
+		req := &http.Request{Host: "service.namespace.svc.cluster.local:8080"}
+		host, err := hm.GetHost(req)
+		assert.NoError(t, err)
+		assert.Equal(t, "service", host.SourceService)
+		assert.Equal(t, "namespace", host.Namespace)
+	})
+
+	t.Run("unknown cross-namespace service rejected", func(t *testing.T) {
+		req := &http.Request{Host: "kube-dns.kube-system.svc.cluster.local:8080"}
+		host, err := hm.GetHost(req)
+		assert.Error(t, err)
+		assert.Equal(t, &messages.Host{}, host)
+		// Rejected hosts must not be cached.
+		_, cached := hm.hosts.Load("kube-dns.kube-system.svc.cluster.local:8080")
+		assert.False(t, cached)
+	})
+
+	t.Run("malformed host rejected", func(t *testing.T) {
+		req := &http.Request{Host: "malicious.attacker"}
+		host, err := hm.GetHost(req)
+		assert.Error(t, err)
+		assert.Equal(t, &messages.Host{}, host)
+	})
 }

--- a/resolver/internal/prom/prom.go
+++ b/resolver/internal/prom/prom.go
@@ -6,6 +6,10 @@ import (
 )
 
 var (
+	// HostExtractionCounter deliberately carries no request-derived free-text labels
+	// (raw Host header, error string). Those are attacker-controlled and would both leak
+	// service/namespace info through /metrics and blow up label cardinality (CWE-200).
+	// "reason" is a fixed, bounded classification set by the resolver.
 	HostExtractionCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "elasti_resolver_host_extraction_count",
@@ -13,9 +17,7 @@ var (
 		},
 		[]string{
 			"extractionType",
-			"source",
-			"hostHeader",
-			"error",
+			"reason",
 		},
 	)
 
@@ -30,6 +32,11 @@ var (
 		},
 	)
 
+	// IncomingRequestHistogram intentionally omits raw request-derived labels
+	// (sourceHost, targetHost, requestURI). requestURI is fully attacker-controlled and
+	// unbounded; the host URLs echo internal DNS/naming conventions. "source"/"target"/
+	// "namespace" are validated against a known ElastiService before this is recorded, so
+	// they are bounded and safe to expose.
 	IncomingRequestHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "elasti_resolver_incoming_requests",
@@ -38,11 +45,8 @@ var (
 		},
 		[]string{"source",
 			"target",
-			"sourceHost",
-			"targetHost",
 			"namespace",
 			"method",
-			"requestURI",
 			"status",
 			"error"},
 	)


### PR DESCRIPTION
## Description

Fixes insufficient Host-header validation in the resolver (CWE-200). An unauthenticated caller could send an arbitrary `Host` header that the resolver accepted, parsed as `service.namespace`, and then cached, exported through Prometheus `/metrics`, notified the operator about, and reverse-proxied - with no check that the service/namespace actually exist. This enabled cross-namespace service discovery, an open-proxy/SSRF path across all namespaces, metrics info-disclosure, and unbounded map growth.

All changes are contained in the resolver; no new dependencies.

1. **Strict Host parsing** (`hostManager.go`) - dropped the catch-all regexes (`([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)` and `([a-zA-Z0-9-]+)`) that matched any two-/single-segment string. Only `<service>.<namespace>.svc[.cluster.local]` is accepted, with each segment validated as an RFC 1123 DNS label (lowercase, ≤63 chars).
2. **ElastiService existence check** (`hostManager.go`, `main.go`) - a well-formed host is still rejected unless a matching `ElastiService` CR exists, using the resolver's existing `crdcache`. This blocks cross-namespace probing and the open-proxy/SSRF vector at the source.
3. **Metrics no longer carry raw request input** (`prom.go`, `handler.go`) - removed the raw `source` (Host), `hostHeader`, free-text `error`, `sourceHost`, `targetHost`, and the attacker-controlled `requestURI` labels (info leak + cardinality risk). Kept bounded, validated labels only. The bundled dashboard only uses `extractionType`/`status`/`le`, all retained.
4. **Unbounded map growth closed** (`hostManager.go`) - the cache key is normalized (path/wildcard stripped) before lookup, and combined with (2) the host cache is now bounded to real services.

**Behavior change:** the resolver now returns 500 for any host that isn't a known `ElastiService`. On resolver startup / for a newly-created `ElastiService`, there is a brief window (up to `crdCachePollIntervalMinutes`, default 5) before the local CRD cache is populated, during which such requests are rejected until the next poll.

**Deferred:** the optional `/metrics` NetworkPolicy from the fix plan - it collides with kubelet liveness/readiness probes on the shared internal port (8013), so it needs a dedicated health port first. The code fix already stops the leak at the source, so this is left as follow-up.

Fixes AUT-146

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Marked as potentially breaking because the resolver now rejects hosts with no matching `ElastiService` and several Prometheus label sets on resolver metrics changed.

## How Has This Been Tested?

- [x] Unit tests for strict parsing: accepts `<svc>.<ns>.svc[.cluster.local]` (with port/path/scheme), rejects the old catch-all forms (`malicious.attacker`, `evil-service`), uppercase, and malformed labels.
- [x] Unit tests for the existence check: known service accepted; unknown cross-namespace host (`kube-dns.kube-system...`) rejected and not cached; malformed host rejected.
- [x] `make test` passes locally across operator, resolver, and pkg.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] A PR is open to update the helm chart (link)[https://github.com/KubeElasti/KubeElasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made
