### PR TITLE
feat: global toggle for security contexts

### DIFF
--- a/charts/elasti/README.md
+++ b/charts/elasti/README.md
@@ -6,27 +6,36 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 
 ### Global parameters for elasti helm chart
 
-| Name                                | Description                                                                                        | Value           |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------- | --------------- |
-| `global.kubernetesClusterDomain`    | domain of the Kubernetes cluster                                                                   | `cluster.local` |
-| `global.allowedNamespaces`          | namespaces to confine KubeElasti to; empty installs cluster-scoped RBAC and watches all namespaces | `[]`            |
-| `global.nameOverride`               | name of the deployment                                                                             | `""`            |
-| `global.fullnameOverride`           | full name of the deployment                                                                        | `""`            |
-| `global.enableMonitoring`           | whether to enable monitoring                                                                       | `false`         |
-| `global.secretName`                 | name of the secret to use for the deployment                                                       | `elasti-secret` |
-| `global.image.registry`             | registry to use for the deployment                                                                 | `ghcr.io`       |
-| `global.imagePullSecrets`           | image pull secrets to use for the deployment                                                       | `[]`            |
-| `global.labels`                     | labels to apply to all resources                                                                   | `{}`            |
-| `global.annotations`                | annotations to apply to all resources                                                              | `{}`            |
-| `global.podLabels`                  | labels to apply to all pods                                                                        | `{}`            |
-| `global.podAnnotations`             | annotations to apply to all pods                                                                   | `{}`            |
-| `global.serviceLabels`              | labels to apply to all services                                                                    | `{}`            |
-| `global.serviceAnnotations`         | annotations to apply to all services                                                               | `{}`            |
-| `global.deploymentLabels`           | labels to apply to all deployments                                                                 | `{}`            |
-| `global.deploymentAnnotations`      | annotations to apply to all deployments                                                            | `{}`            |
-| `global.serviceAccount`             | service account configuration                                                                      | `{}`            |
-| `global.serviceAccount.annotations` | annotations to apply to all service accounts                                                       | `{}`            |
-| `global.serviceAccount.labels`      | labels to apply to all service accounts                                                            | `{}`            |
+| Name                                                       | Description                                                                                                                         | Value            |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `global.kubernetesClusterDomain`                           | domain of the Kubernetes cluster                                                                                                    | `cluster.local`  |
+| `global.allowedNamespaces`                                 | namespaces to confine KubeElasti to; empty installs cluster-scoped RBAC and watches all namespaces                                  | `[]`             |
+| `global.nameOverride`                                      | name of the deployment                                                                                                              | `""`             |
+| `global.fullnameOverride`                                  | full name of the deployment                                                                                                         | `""`             |
+| `global.enableMonitoring`                                  | whether to enable monitoring                                                                                                        | `false`          |
+| `global.secretName`                                        | name of the secret to use for the deployment                                                                                        | `elasti-secret`  |
+| `global.image.registry`                                    | registry to use for the deployment                                                                                                  | `ghcr.io`        |
+| `global.imagePullSecrets`                                  | image pull secrets to use for the deployment                                                                                        | `[]`             |
+| `global.labels`                                            | labels to apply to all resources                                                                                                    | `{}`             |
+| `global.annotations`                                       | annotations to apply to all resources                                                                                               | `{}`             |
+| `global.podLabels`                                         | labels to apply to all pods                                                                                                         | `{}`             |
+| `global.podAnnotations`                                    | annotations to apply to all pods                                                                                                    | `{}`             |
+| `global.serviceLabels`                                     | labels to apply to all services                                                                                                     | `{}`             |
+| `global.serviceAnnotations`                                | annotations to apply to all services                                                                                                | `{}`             |
+| `global.deploymentLabels`                                  | labels to apply to all deployments                                                                                                  | `{}`             |
+| `global.deploymentAnnotations`                             | annotations to apply to all deployments                                                                                             | `{}`             |
+| `global.serviceAccount`                                    | service account configuration                                                                                                       | `{}`             |
+| `global.serviceAccount.annotations`                        | annotations to apply to all service accounts                                                                                        | `{}`             |
+| `global.serviceAccount.labels`                             | labels to apply to all service accounts                                                                                             | `{}`             |
+| `global.podSecurityContext.enabled`                        | toggle pod security contexts for all elasti components; set false to drop them (e.g. on OpenShift/ROSA so the platform assigns IDs) | `true`           |
+| `global.podSecurityContext.runAsNonRoot`                   | default runAsNonRoot for all elasti component pods; a component can override per field                                              | `true`           |
+| `global.podSecurityContext.runAsUser`                      | default runAsUser (UID) for all elasti component pods; a component can override per field                                           | `65532`          |
+| `global.podSecurityContext.runAsGroup`                     | default runAsGroup (GID) for all elasti component pods; a component can override per field                                          | `65532`          |
+| `global.podSecurityContext.seccompProfile.type`            | default seccomp profile for all elasti component pods                                                                               | `RuntimeDefault` |
+| `global.containerSecurityContext.enabled`                  | toggle container security contexts for all elasti components                                                                        | `true`           |
+| `global.containerSecurityContext.allowPrivilegeEscalation` | default allowPrivilegeEscalation for all elasti component containers                                                                | `false`          |
+| `global.containerSecurityContext.readOnlyRootFilesystem`   | default readOnlyRootFilesystem for all elasti component containers                                                                  | `true`           |
+| `global.containerSecurityContext.capabilities.drop`        | default dropped capabilities for all elasti component containers                                                                    | `[]`             |
 
 ### Elasti controller parameters
 

--- a/charts/elasti/templates/_helpers.tpl
+++ b/charts/elasti/templates/_helpers.tpl
@@ -5,6 +5,22 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.global.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/* Merged pod securityContext, local-over-global; */}}
+{{- define "elasti.podSecurityContext" -}}
+{{- $l := .local | default dict -}}{{- $g := .global | default dict -}}
+{{- if ternary $l.enabled $g.enabled (hasKey $l "enabled") -}}
+{{- toYaml (mergeOverwrite (deepCopy (omit $g "enabled")) (omit $l "enabled")) -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Merged container securityContext, local-over-global; */}}
+{{- define "elasti.containerSecurityContext" -}}
+{{- $l := .local | default dict -}}{{- $g := .global | default dict -}}
+{{- if ternary $l.enabled $g.enabled (hasKey $l "enabled") -}}
+{{- toYaml (mergeOverwrite (deepCopy (omit $g "enabled")) (omit $l "enabled")) -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/elasti/templates/deployment.yaml
+++ b/charts/elasti/templates/deployment.yaml
@@ -74,10 +74,14 @@ spec:
           periodSeconds: 10
         resources:
           {{- toYaml .Values.elastiController.manager.resources | nindent 10 }}
+        {{- with (include "elasti.containerSecurityContext" (dict "local" .Values.elastiController.manager.containerSecurityContext "global" .Values.global.containerSecurityContext)) }}
         securityContext:
-          {{- toYaml .Values.elastiController.manager.containerSecurityContext | nindent 10 }}
+          {{- . | nindent 10 }}
+        {{- end }}
+      {{- with (include "elasti.podSecurityContext" (dict "local" .Values.elastiController.manager.podSecurityContext "global" .Values.global.podSecurityContext)) }}
       securityContext:
-        {{- toYaml .Values.elastiController.manager.podSecurityContext | nindent 8 }}
+        {{- . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "elasti.fullname" . }}-operator-controller-manager
       terminationGracePeriodSeconds: 10
       imagePullSecrets:
@@ -179,10 +183,14 @@ spec:
           periodSeconds: 10
         resources:
           {{- toYaml .Values.elastiResolver.proxy.resources | nindent 10 }}
+        {{- with (include "elasti.containerSecurityContext" (dict "local" .Values.elastiResolver.proxy.containerSecurityContext "global" .Values.global.containerSecurityContext)) }}
         securityContext:
-          {{- toYaml .Values.elastiResolver.proxy.containerSecurityContext | nindent 10 }}
+          {{- . | nindent 10 }}
+        {{- end }}
+      {{- with (include "elasti.podSecurityContext" (dict "local" .Values.elastiResolver.proxy.podSecurityContext "global" .Values.global.podSecurityContext)) }}
       securityContext:
-        {{- toYaml .Values.elastiResolver.proxy.podSecurityContext | nindent 8 }}
+        {{- . | nindent 8 }}
+      {{- end }}
       imagePullSecrets:
         {{- include "elasti.imagePullSecrets" . | nindent 8 }}
       serviceAccountName: {{ include "elasti.fullname" . }}-resolver

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -56,6 +56,31 @@ global:
     annotations: {}
     ## @param global.serviceAccount.labels [object] labels to apply to all service accounts
     labels: {}
+  ## @param global.podSecurityContext.enabled toggle pod security contexts for all elasti components
+  ##
+  podSecurityContext:
+    enabled: true
+    ## @param global.podSecurityContext.runAsNonRoot default runAsNonRoot for all elasti component pods; a component can override per field
+    runAsNonRoot: true
+    ## @param global.podSecurityContext.runAsUser default runAsUser (UID) for all elasti component pods; a component can override per field
+    runAsUser: 65532
+    ## @param global.podSecurityContext.runAsGroup default runAsGroup (GID) for all elasti component pods; a component can override per field
+    runAsGroup: 65532
+    ## @param global.podSecurityContext.seccompProfile.type default seccomp profile for all elasti component pods
+    seccompProfile:
+      type: RuntimeDefault
+  ## @param global.containerSecurityContext.enabled toggle container security contexts for all elasti components
+  ##
+  containerSecurityContext:
+    enabled: true
+    ## @param global.containerSecurityContext.allowPrivilegeEscalation default allowPrivilegeEscalation for all elasti component containers
+    allowPrivilegeEscalation: false
+    ## @param global.containerSecurityContext.readOnlyRootFilesystem default readOnlyRootFilesystem for all elasti component containers
+    readOnlyRootFilesystem: true
+    ## @param global.containerSecurityContext.capabilities.drop [array] default dropped capabilities for all elasti component containers
+    capabilities:
+      drop:
+        - ALL
 ## @section Elasti controller parameters
 elastiController:
   manager:
@@ -65,22 +90,12 @@ elastiController:
       - --leader-elect
       - --health-probe-bind-address=:8081
       - --metrics-bind-address=0
-    ## @param elastiController.manager.containerSecurityContext [object] container security context
+    ## @param elastiController.manager.containerSecurityContext [object] container security context. Inherits global.containerSecurityContext; set fields here (or `enabled: false`) to override.
     ##
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop:
-          - ALL
-    ## @param elastiController.manager.podSecurityContext [object] pod security context
+    containerSecurityContext: {}
+    ## @param elastiController.manager.podSecurityContext [object] pod security context. Inherits global.podSecurityContext; set fields here (or `enabled: false`) to override.
     ##
-    podSecurityContext:
-      runAsNonRoot: true
-      runAsUser: 65532
-      runAsGroup: 65532
-      seccompProfile:
-        type: RuntimeDefault
+    podSecurityContext: {}
     ## @param elastiController.manager.image.registry registry to use for the deployment
     ##
     image:
@@ -230,23 +245,13 @@ elastiResolver:
         cpu: 100m
         memory: 40Mi
 
-    ## @param elastiResolver.proxy.containerSecurityContext [object] container security context
+    ## @param elastiResolver.proxy.containerSecurityContext [object] container security context. Inherits global.containerSecurityContext; set fields here (or `enabled: false`) to override.
     ##
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-      capabilities:
-        drop:
-          - ALL
+    containerSecurityContext: {}
 
-    ## @param elastiResolver.proxy.podSecurityContext [object] pod security context
+    ## @param elastiResolver.proxy.podSecurityContext [object] pod security context. Inherits global.podSecurityContext; set fields here (or `enabled: false`) to override.
     ##
-    podSecurityContext:
-      runAsNonRoot: true
-      runAsUser: 65532
-      runAsGroup: 65532
-      seccompProfile:
-        type: RuntimeDefault
+    podSecurityContext: {}
 
     sentry:
       ## @param elastiResolver.proxy.sentry.enabled whether to enable sentry


### PR DESCRIPTION

## Description
Add global.podSecurityContext.enabled / global.containerSecurityContext.enabled toggles to turn security contexts on/off chart-wide (e.g. on OpenShift/ROSA where the platform assigns IDs); each component can still override per field. Move the shared securityContext defaults into global so they are defined once and inherited via new elasti.podSecurityContext / elasti.containerSecurityContext helpers.


Fixes # (issue)

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes 
- [ ] A PR is open to update the helm chart (link)[https://github.com/KubeElasti/KubeElasti/tree/main/charts/elasti] if applicable
- [ ] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made
