### PR TITLE
feat: add google analytics property

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,9 @@ plugins:
       cache_safe: true
 
 extra:
+  analytics:
+    provider: google
+    property: G-MMVMBYSN0Z
   scope: /
   # Browser chrome (theme-color / TileColor); aligns with Material `primary: teal` default palette
   theme_color: "#00796b"


### PR DESCRIPTION
Enable Google Analytics (GA4) on the docs site via Material’s built-in analytics config (G-MMVMBYSN0Z)