### PR TITLE
release: v0.1.31-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ All the unreleased changes are listed under `Unreleased` section. Add your chang
 
 ## Unreleased
 
+## v0.1.31-rc2 (2026-08-06)
+
+### Improvements
+
+* feat: add `global.podSecurityContext.enabled` and `global.containerSecurityContext.enabled` toggles to turn security contexts on or off chart-wide (useful on OpenShift/ROSA where the platform assigns IDs); each component can still override individual fields by `@abhishekpradeep124` in [#346](https://github.com/KubeElasti/KubeElasti/pull/346)
+
+### Fixes
+
+* fix: pin build and release workflow dependencies by hash, satisfying the OpenSSF Scorecard Pinned-Dependencies check by `@ramantehlan` in [#325](https://github.com/KubeElasti/KubeElasti/pull/325)
+
+### Other
+
+* feat: add Google Analytics property to the docs site by `@ramantehlan` in [#347](https://github.com/KubeElasti/KubeElasti/pull/347)
+* docs: target ~90% unit-test coverage and disable dependabot by `@ramantehlan` in [#344](https://github.com/KubeElasti/KubeElasti/pull/344)
+* deps: bump `k8s.io/apimachinery` from 0.34.1 to 0.36.3 in /resolver by `@dependabot` in [#340](https://github.com/KubeElasti/KubeElasti/pull/340)
+* ci: bump `docker/setup-buildx-action` from 3.12.0 to 4.2.0 by `@dependabot` in [#330](https://github.com/KubeElasti/KubeElasti/pull/330)
+* ci: bump `codecov/codecov-action` from 5.5.5 to 7.0.0 by `@dependabot` in [#329](https://github.com/KubeElasti/KubeElasti/pull/329)
+* ci: bump `actions/setup-go` from 4.3.0 to 7.0.0 by `@dependabot` in [#328](https://github.com/KubeElasti/KubeElasti/pull/328)
+* ci: bump `actions/stale` from 9.0.0 to 11.0.0 by `@dependabot` in [#327](https://github.com/KubeElasti/KubeElasti/pull/327)
+* ci: bump `sigstore/cosign-installer` from 3.9.1 to 4.1.2 by `@dependabot` in [#326](https://github.com/KubeElasti/KubeElasti/pull/326)
+
+### New Contributors
+
+* `@abhishekpradeep124` made their first contribution in [#346](https://github.com/KubeElasti/KubeElasti/pull/346)
+
 ## v0.1.31-rc1 (2026-07-29)
 
 ### Fixes

--- a/charts/elasti/Chart.yaml
+++ b/charts/elasti/Chart.yaml
@@ -3,8 +3,8 @@ name: elasti
 description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionality when there is no traffic and automatic scale up to 1 when traffic arrives.
 icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/assets/images/logo/rounded_colour_white_bg.png
 type: application
-version: 0.1.31-rc1
-appVersion: "0.1.31-rc1"
+version: 0.1.31-rc2
+appVersion: "0.1.31-rc2"
 # kubeVersion: ">=1.25.0-0"
 home: https://kubeelasti.dev
 sources:

--- a/charts/elasti/README.md
+++ b/charts/elasti/README.md
@@ -6,108 +6,108 @@ KubeElasti is a Kubernetes-native solution that offers scale-to-zero functionali
 
 ### Global parameters for elasti helm chart
 
-| Name                                                       | Description                                                                                                                         | Value            |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `global.kubernetesClusterDomain`                           | domain of the Kubernetes cluster                                                                                                    | `cluster.local`  |
-| `global.allowedNamespaces`                                 | namespaces to confine KubeElasti to; empty installs cluster-scoped RBAC and watches all namespaces                                  | `[]`             |
-| `global.nameOverride`                                      | name of the deployment                                                                                                              | `""`             |
-| `global.fullnameOverride`                                  | full name of the deployment                                                                                                         | `""`             |
-| `global.enableMonitoring`                                  | whether to enable monitoring                                                                                                        | `false`          |
-| `global.secretName`                                        | name of the secret to use for the deployment                                                                                        | `elasti-secret`  |
-| `global.image.registry`                                    | registry to use for the deployment                                                                                                  | `ghcr.io`        |
-| `global.imagePullSecrets`                                  | image pull secrets to use for the deployment                                                                                        | `[]`             |
-| `global.labels`                                            | labels to apply to all resources                                                                                                    | `{}`             |
-| `global.annotations`                                       | annotations to apply to all resources                                                                                               | `{}`             |
-| `global.podLabels`                                         | labels to apply to all pods                                                                                                         | `{}`             |
-| `global.podAnnotations`                                    | annotations to apply to all pods                                                                                                    | `{}`             |
-| `global.serviceLabels`                                     | labels to apply to all services                                                                                                     | `{}`             |
-| `global.serviceAnnotations`                                | annotations to apply to all services                                                                                                | `{}`             |
-| `global.deploymentLabels`                                  | labels to apply to all deployments                                                                                                  | `{}`             |
-| `global.deploymentAnnotations`                             | annotations to apply to all deployments                                                                                             | `{}`             |
-| `global.serviceAccount`                                    | service account configuration                                                                                                       | `{}`             |
-| `global.serviceAccount.annotations`                        | annotations to apply to all service accounts                                                                                        | `{}`             |
-| `global.serviceAccount.labels`                             | labels to apply to all service accounts                                                                                             | `{}`             |
-| `global.podSecurityContext.enabled`                        | toggle pod security contexts for all elasti components; set false to drop them (e.g. on OpenShift/ROSA so the platform assigns IDs) | `true`           |
-| `global.podSecurityContext.runAsNonRoot`                   | default runAsNonRoot for all elasti component pods; a component can override per field                                              | `true`           |
-| `global.podSecurityContext.runAsUser`                      | default runAsUser (UID) for all elasti component pods; a component can override per field                                           | `65532`          |
-| `global.podSecurityContext.runAsGroup`                     | default runAsGroup (GID) for all elasti component pods; a component can override per field                                          | `65532`          |
-| `global.podSecurityContext.seccompProfile.type`            | default seccomp profile for all elasti component pods                                                                               | `RuntimeDefault` |
-| `global.containerSecurityContext.enabled`                  | toggle container security contexts for all elasti components                                                                        | `true`           |
-| `global.containerSecurityContext.allowPrivilegeEscalation` | default allowPrivilegeEscalation for all elasti component containers                                                                | `false`          |
-| `global.containerSecurityContext.readOnlyRootFilesystem`   | default readOnlyRootFilesystem for all elasti component containers                                                                  | `true`           |
-| `global.containerSecurityContext.capabilities.drop`        | default dropped capabilities for all elasti component containers                                                                    | `[]`             |
+| Name                                                       | Description                                                                                        | Value            |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------- |
+| `global.kubernetesClusterDomain`                           | domain of the Kubernetes cluster                                                                   | `cluster.local`  |
+| `global.allowedNamespaces`                                 | namespaces to confine KubeElasti to; empty installs cluster-scoped RBAC and watches all namespaces | `[]`             |
+| `global.nameOverride`                                      | name of the deployment                                                                             | `""`             |
+| `global.fullnameOverride`                                  | full name of the deployment                                                                        | `""`             |
+| `global.enableMonitoring`                                  | whether to enable monitoring                                                                       | `false`          |
+| `global.secretName`                                        | name of the secret to use for the deployment                                                       | `elasti-secret`  |
+| `global.image.registry`                                    | registry to use for the deployment                                                                 | `ghcr.io`        |
+| `global.imagePullSecrets`                                  | image pull secrets to use for the deployment                                                       | `[]`             |
+| `global.labels`                                            | labels to apply to all resources                                                                   | `{}`             |
+| `global.annotations`                                       | annotations to apply to all resources                                                              | `{}`             |
+| `global.podLabels`                                         | labels to apply to all pods                                                                        | `{}`             |
+| `global.podAnnotations`                                    | annotations to apply to all pods                                                                   | `{}`             |
+| `global.serviceLabels`                                     | labels to apply to all services                                                                    | `{}`             |
+| `global.serviceAnnotations`                                | annotations to apply to all services                                                               | `{}`             |
+| `global.deploymentLabels`                                  | labels to apply to all deployments                                                                 | `{}`             |
+| `global.deploymentAnnotations`                             | annotations to apply to all deployments                                                            | `{}`             |
+| `global.serviceAccount`                                    | service account configuration                                                                      | `{}`             |
+| `global.serviceAccount.annotations`                        | annotations to apply to all service accounts                                                       | `{}`             |
+| `global.serviceAccount.labels`                             | labels to apply to all service accounts                                                            | `{}`             |
+| `global.podSecurityContext.enabled`                        | toggle pod security contexts for all elasti components                                             | `true`           |
+| `global.podSecurityContext.runAsNonRoot`                   | default runAsNonRoot for all elasti component pods; a component can override per field             | `true`           |
+| `global.podSecurityContext.runAsUser`                      | default runAsUser (UID) for all elasti component pods; a component can override per field          | `65532`          |
+| `global.podSecurityContext.runAsGroup`                     | default runAsGroup (GID) for all elasti component pods; a component can override per field         | `65532`          |
+| `global.podSecurityContext.seccompProfile.type`            | default seccomp profile for all elasti component pods                                              | `RuntimeDefault` |
+| `global.containerSecurityContext.enabled`                  | toggle container security contexts for all elasti components                                       | `true`           |
+| `global.containerSecurityContext.allowPrivilegeEscalation` | default allowPrivilegeEscalation for all elasti component containers                               | `false`          |
+| `global.containerSecurityContext.readOnlyRootFilesystem`   | default readOnlyRootFilesystem for all elasti component containers                                 | `true`           |
+| `global.containerSecurityContext.capabilities.drop`        | default dropped capabilities for all elasti component containers                                   | `[]`             |
 
 ### Elasti controller parameters
 
-| Name                                                | Description                                            | Value                        |
-| --------------------------------------------------- | ------------------------------------------------------ | ---------------------------- |
-| `elastiController.manager.args`                     | arguments to pass to the manager                       | `[]`                         |
-| `elastiController.manager.containerSecurityContext` | container security context                             | `{}`                         |
-| `elastiController.manager.podSecurityContext`       | pod security context                                   | `{}`                         |
-| `elastiController.manager.image.registry`           | registry to use for the deployment                     | `""`                         |
-| `elastiController.manager.image.repository`         | repository to use for the deployment                   | `kubeelasti/elasti-operator` |
-| `elastiController.manager.image.tag`                | tag to use for the deployment                          | `0.1.31-rc1`                 |
-| `elastiController.manager.imagePullPolicy`          | image pull policy                                      | `IfNotPresent`               |
-| `elastiController.manager.resources`                | resources to use for the deployment                    | `{}`                         |
-| `elastiController.manager.sentry.enabled`           | whether to enable sentry                               | `false`                      |
-| `elastiController.manager.sentry.environment`       | environment to use for the deployment                  | `""`                         |
-| `elastiController.manager.env`                      | environment to use for the deployment                  | `{}`                         |
-| `elastiController.replicas`                         | number of replicas to use for the deployment           | `1`                          |
-| `elastiController.commonLabels`                     | labels to apply to all elastiController resources      | `{}`                         |
-| `elastiController.commonAnnotations`                | annotations to apply to all elastiController resources | `{}`                         |
-| `elastiController.podLabels`                        | labels to apply to elastiController pods               | `{}`                         |
-| `elastiController.podAnnotations`                   | annotations to apply to elastiController pods          | `{}`                         |
-| `elastiController.deploymentLabels`                 | labels to apply to elastiController deployment         | `{}`                         |
-| `elastiController.deploymentAnnotations`            | annotations to apply to elastiController deployment    | `{}`                         |
-| `elastiController.affinity`                         | affinity rules for pod assignment                      | `{}`                         |
-| `elastiController.nodeSelector`                     | node labels for pod assignment                         | `{}`                         |
-| `elastiController.tolerations`                      | tolerations for pod assignment                         | `[]`                         |
-| `elastiController.serviceAccount.annotations`       | annotations to use for the deployment                  | `{}`                         |
-| `elastiController.serviceAccount.labels`            | labels to use for the service account                  | `{}`                         |
-| `elastiController.metricsService`                   | metrics service to use for the deployment              | `{}`                         |
-| `elastiController.metricsService.labels`            | labels to apply to metricsService                      | `{}`                         |
-| `elastiController.metricsService.annotations`       | annotations to apply to metricsService                 | `{}`                         |
-| `elastiController.service`                          | service to use for the deployment                      | `{}`                         |
-| `elastiController.service.labels`                   | labels to apply to service                             | `{}`                         |
-| `elastiController.service.annotations`              | annotations to apply to service                        | `{}`                         |
-| `elastiController.serviceMonitor`                   | serviceMonitor configuration                           | `{}`                         |
-| `elastiController.serviceMonitor.labels`            | labels to apply to serviceMonitor                      | `{}`                         |
-| `elastiController.serviceMonitor.annotations`       | annotations to apply to serviceMonitor                 | `{}`                         |
+| Name                                                | Description                                                                                                              | Value                        |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| `elastiController.manager.args`                     | arguments to pass to the manager                                                                                         | `[]`                         |
+| `elastiController.manager.containerSecurityContext` | container security context. Inherits global.containerSecurityContext; set fields here (or `enabled: false`) to override. | `{}`                         |
+| `elastiController.manager.podSecurityContext`       | pod security context. Inherits global.podSecurityContext; set fields here (or `enabled: false`) to override.             | `{}`                         |
+| `elastiController.manager.image.registry`           | registry to use for the deployment                                                                                       | `""`                         |
+| `elastiController.manager.image.repository`         | repository to use for the deployment                                                                                     | `kubeelasti/elasti-operator` |
+| `elastiController.manager.image.tag`                | tag to use for the deployment                                                                                            | `0.1.31-rc2`                 |
+| `elastiController.manager.imagePullPolicy`          | image pull policy                                                                                                        | `IfNotPresent`               |
+| `elastiController.manager.resources`                | resources to use for the deployment                                                                                      | `{}`                         |
+| `elastiController.manager.sentry.enabled`           | whether to enable sentry                                                                                                 | `false`                      |
+| `elastiController.manager.sentry.environment`       | environment to use for the deployment                                                                                    | `""`                         |
+| `elastiController.manager.env`                      | environment to use for the deployment                                                                                    | `{}`                         |
+| `elastiController.replicas`                         | number of replicas to use for the deployment                                                                             | `1`                          |
+| `elastiController.commonLabels`                     | labels to apply to all elastiController resources                                                                        | `{}`                         |
+| `elastiController.commonAnnotations`                | annotations to apply to all elastiController resources                                                                   | `{}`                         |
+| `elastiController.podLabels`                        | labels to apply to elastiController pods                                                                                 | `{}`                         |
+| `elastiController.podAnnotations`                   | annotations to apply to elastiController pods                                                                            | `{}`                         |
+| `elastiController.deploymentLabels`                 | labels to apply to elastiController deployment                                                                           | `{}`                         |
+| `elastiController.deploymentAnnotations`            | annotations to apply to elastiController deployment                                                                      | `{}`                         |
+| `elastiController.affinity`                         | affinity rules for pod assignment                                                                                        | `{}`                         |
+| `elastiController.nodeSelector`                     | node labels for pod assignment                                                                                           | `{}`                         |
+| `elastiController.tolerations`                      | tolerations for pod assignment                                                                                           | `[]`                         |
+| `elastiController.serviceAccount.annotations`       | annotations to use for the deployment                                                                                    | `{}`                         |
+| `elastiController.serviceAccount.labels`            | labels to use for the service account                                                                                    | `{}`                         |
+| `elastiController.metricsService`                   | metrics service to use for the deployment                                                                                | `{}`                         |
+| `elastiController.metricsService.labels`            | labels to apply to metricsService                                                                                        | `{}`                         |
+| `elastiController.metricsService.annotations`       | annotations to apply to metricsService                                                                                   | `{}`                         |
+| `elastiController.service`                          | service to use for the deployment                                                                                        | `{}`                         |
+| `elastiController.service.labels`                   | labels to apply to service                                                                                               | `{}`                         |
+| `elastiController.service.annotations`              | annotations to apply to service                                                                                          | `{}`                         |
+| `elastiController.serviceMonitor`                   | serviceMonitor configuration                                                                                             | `{}`                         |
+| `elastiController.serviceMonitor.labels`            | labels to apply to serviceMonitor                                                                                        | `{}`                         |
+| `elastiController.serviceMonitor.annotations`       | annotations to apply to serviceMonitor                                                                                   | `{}`                         |
 
 ### Elasti resolver parameters
 
-| Name                                                        | Description                                                 | Value                        |
-| ----------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------- |
-| `elastiResolver.proxy.env`                                  | environment to use for the deployment                       | `{}`                         |
-| `elastiResolver.proxy.image.registry`                       | registry to use for the deployment                          | `""`                         |
-| `elastiResolver.proxy.image.repository`                     | repository to use for the deployment                        | `kubeelasti/elasti-resolver` |
-| `elastiResolver.proxy.image.tag`                            | tag to use for the deployment                               | `0.1.31-rc1`                 |
-| `elastiResolver.proxy.imagePullPolicy`                      | image pull policy                                           | `IfNotPresent`               |
-| `elastiResolver.proxy.resources`                            | resources to use for the deployment                         | `{}`                         |
-| `elastiResolver.proxy.containerSecurityContext`             | container security context                                  | `{}`                         |
-| `elastiResolver.proxy.podSecurityContext`                   | pod security context                                        | `{}`                         |
-| `elastiResolver.proxy.sentry.enabled`                       | whether to enable sentry                                    | `false`                      |
-| `elastiResolver.proxy.sentry.environment`                   | environment to use for the deployment                       | `""`                         |
-| `elastiResolver.replicas`                                   | number of replicas to use for the deployment                | `1`                          |
-| `elastiResolver.commonLabels`                               | labels to apply to all elastiResolver resources             | `{}`                         |
-| `elastiResolver.commonAnnotations`                          | annotations to apply to all elastiResolver resources        | `{}`                         |
-| `elastiResolver.podLabels`                                  | labels to apply to elastiResolver pods                      | `{}`                         |
-| `elastiResolver.podAnnotations`                             | annotations to apply to elastiResolver pods                 | `{}`                         |
-| `elastiResolver.deploymentLabels`                           | labels to apply to elastiResolver deployment                | `{}`                         |
-| `elastiResolver.deploymentAnnotations`                      | annotations to apply to elastiResolver deployment           | `{}`                         |
-| `elastiResolver.affinity`                                   | affinity rules for pod assignment                           | `{}`                         |
-| `elastiResolver.nodeSelector`                               | node labels for pod assignment                              | `{}`                         |
-| `elastiResolver.tolerations`                                | tolerations for pod assignment                              | `[]`                         |
-| `elastiResolver.serviceAccount.annotations`                 | annotations to use for the deployment                       | `{}`                         |
-| `elastiResolver.serviceAccount.labels`                      | labels to use for the service account                       | `{}`                         |
-| `elastiResolver.autoscaling.enabled`                        | whether to enable autoscaling                               | `false`                      |
-| `elastiResolver.autoscaling.minReplicas`                    | minimum number of replicas to use for the deployment        | `1`                          |
-| `elastiResolver.autoscaling.maxReplicas`                    | maximum number of replicas to use for the deployment        | `4`                          |
-| `elastiResolver.autoscaling.targetCPUUtilizationPercentage` | target CPU utilization percentage to use for the deployment | `70`                         |
-| `elastiResolver.reverseProxyService`                        | reverse proxy service to use for the deployment             | `{}`                         |
-| `elastiResolver.service`                                    | service to use for the deployment                           | `{}`                         |
-| `elastiResolver.service.labels`                             | labels to apply to service                                  | `{}`                         |
-| `elastiResolver.service.annotations`                        | annotations to apply to service                             | `{}`                         |
-| `elastiResolver.serviceMonitor`                             | serviceMonitor configuration                                | `{}`                         |
-| `elastiResolver.serviceMonitor.labels`                      | labels to apply to serviceMonitor                           | `{}`                         |
-| `elastiResolver.serviceMonitor.annotations`                 | annotations to apply to serviceMonitor                      | `{}`                         |
+| Name                                                        | Description                                                                                                              | Value                        |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| `elastiResolver.proxy.env`                                  | environment to use for the deployment                                                                                    | `{}`                         |
+| `elastiResolver.proxy.image.registry`                       | registry to use for the deployment                                                                                       | `""`                         |
+| `elastiResolver.proxy.image.repository`                     | repository to use for the deployment                                                                                     | `kubeelasti/elasti-resolver` |
+| `elastiResolver.proxy.image.tag`                            | tag to use for the deployment                                                                                            | `0.1.31-rc2`                 |
+| `elastiResolver.proxy.imagePullPolicy`                      | image pull policy                                                                                                        | `IfNotPresent`               |
+| `elastiResolver.proxy.resources`                            | resources to use for the deployment                                                                                      | `{}`                         |
+| `elastiResolver.proxy.containerSecurityContext`             | container security context. Inherits global.containerSecurityContext; set fields here (or `enabled: false`) to override. | `{}`                         |
+| `elastiResolver.proxy.podSecurityContext`                   | pod security context. Inherits global.podSecurityContext; set fields here (or `enabled: false`) to override.             | `{}`                         |
+| `elastiResolver.proxy.sentry.enabled`                       | whether to enable sentry                                                                                                 | `false`                      |
+| `elastiResolver.proxy.sentry.environment`                   | environment to use for the deployment                                                                                    | `""`                         |
+| `elastiResolver.replicas`                                   | number of replicas to use for the deployment                                                                             | `1`                          |
+| `elastiResolver.commonLabels`                               | labels to apply to all elastiResolver resources                                                                          | `{}`                         |
+| `elastiResolver.commonAnnotations`                          | annotations to apply to all elastiResolver resources                                                                     | `{}`                         |
+| `elastiResolver.podLabels`                                  | labels to apply to elastiResolver pods                                                                                   | `{}`                         |
+| `elastiResolver.podAnnotations`                             | annotations to apply to elastiResolver pods                                                                              | `{}`                         |
+| `elastiResolver.deploymentLabels`                           | labels to apply to elastiResolver deployment                                                                             | `{}`                         |
+| `elastiResolver.deploymentAnnotations`                      | annotations to apply to elastiResolver deployment                                                                        | `{}`                         |
+| `elastiResolver.affinity`                                   | affinity rules for pod assignment                                                                                        | `{}`                         |
+| `elastiResolver.nodeSelector`                               | node labels for pod assignment                                                                                           | `{}`                         |
+| `elastiResolver.tolerations`                                | tolerations for pod assignment                                                                                           | `[]`                         |
+| `elastiResolver.serviceAccount.annotations`                 | annotations to use for the deployment                                                                                    | `{}`                         |
+| `elastiResolver.serviceAccount.labels`                      | labels to use for the service account                                                                                    | `{}`                         |
+| `elastiResolver.autoscaling.enabled`                        | whether to enable autoscaling                                                                                            | `false`                      |
+| `elastiResolver.autoscaling.minReplicas`                    | minimum number of replicas to use for the deployment                                                                     | `1`                          |
+| `elastiResolver.autoscaling.maxReplicas`                    | maximum number of replicas to use for the deployment                                                                     | `4`                          |
+| `elastiResolver.autoscaling.targetCPUUtilizationPercentage` | target CPU utilization percentage to use for the deployment                                                              | `70`                         |
+| `elastiResolver.reverseProxyService`                        | reverse proxy service to use for the deployment                                                                          | `{}`                         |
+| `elastiResolver.service`                                    | service to use for the deployment                                                                                        | `{}`                         |
+| `elastiResolver.service.labels`                             | labels to apply to service                                                                                               | `{}`                         |
+| `elastiResolver.service.annotations`                        | annotations to apply to service                                                                                          | `{}`                         |
+| `elastiResolver.serviceMonitor`                             | serviceMonitor configuration                                                                                             | `{}`                         |
+| `elastiResolver.serviceMonitor.labels`                      | labels to apply to serviceMonitor                                                                                        | `{}`                         |
+| `elastiResolver.serviceMonitor.annotations`                 | annotations to apply to serviceMonitor                                                                                   | `{}`                         |

--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -105,7 +105,7 @@ elastiController:
       repository: kubeelasti/elasti-operator
       ## @param elastiController.manager.image.tag tag to use for the deployment
       ##
-      tag: 0.1.31-rc1
+      tag: 0.1.31-rc2
     ## @param elastiController.manager.imagePullPolicy image pull policy
     ##
     imagePullPolicy: IfNotPresent
@@ -237,7 +237,7 @@ elastiResolver:
       repository: kubeelasti/elasti-resolver
       ## @param elastiResolver.proxy.image.tag tag to use for the deployment
       ##
-      tag: 0.1.31-rc1
+      tag: 0.1.31-rc2
     ## @param elastiResolver.proxy.imagePullPolicy image pull policy
     ##
     imagePullPolicy: IfNotPresent

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -10,6 +10,35 @@ entries:
           url: https://slack.cncf.io/
       artifacthub.io/operator: "true"
     apiVersion: v2
+    appVersion: 0.1.31-rc2
+    created: "2026-08-06T09:22:24.404003011Z"
+    description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
+      functionality when there is no traffic and automatic scale up to 1 when traffic
+      arrives.
+    digest: 1f6d8bc929c92fc2a43a64ccc0a1e1b9008c028c00b0a8ed41ba236013540be3
+    home: https://kubeelasti.dev
+    icon: https://raw.githubusercontent.com/KubeElasti/KubeElasti/refs/heads/main/docs/assets/images/logo/rounded_colour_white_bg.png
+    keywords:
+    - Scale-to-zero
+    - Operator
+    - Cloud Native
+    - Autoscaling
+    name: elasti
+    sources:
+    - https://github.com/KubeElasti/KubeElasti
+    type: application
+    urls:
+    - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.31-rc2/elasti-0.1.31-rc2.tgz
+    version: 0.1.31-rc2
+  - annotations:
+      artifacthub.io/license: MIT
+      artifacthub.io/links: |
+        - name: Source
+          url: https://github.com/KubeElasti/KubeElasti
+        - name: CNCF Slack (#kubeelasti)
+          url: https://slack.cncf.io/
+      artifacthub.io/operator: "true"
+    apiVersion: v2
     appVersion: 0.1.31-rc1
     created: "2026-07-29T09:06:56.483862875Z"
     description: KubeElasti is a Kubernetes-native solution that offers scale-to-zero
@@ -243,4 +272,4 @@ entries:
     urls:
     - https://github.com/KubeElasti/KubeElasti/releases/download/v0.1.20/elasti-0.1.20.tgz
     version: 0.1.20
-generated: "2026-07-29T09:06:56.48269458Z"
+generated: "2026-08-06T09:22:24.40281914Z"


### PR DESCRIPTION
Prepares `v0.1.31-rc2`.

- `charts/elasti/Chart.yaml`: `version` and `appVersion` -> `0.1.31-rc2`
- `charts/elasti/values.yaml`: operator and resolver image tags -> `0.1.31-rc2`
- `CHANGELOG.md`: new `v0.1.31-rc2` section

## Changes since v0.1.31-rc1

### Improvements

* feat: add `global.podSecurityContext.enabled` and `global.containerSecurityContext.enabled` toggles to turn security contexts on or off chart-wide (useful on OpenShift/ROSA where the platform assigns IDs); each component can still override individual fields by `@abhishekpradeep124` in #346

### Fixes

* fix: pin build and release workflow dependencies by hash, satisfying the OpenSSF Scorecard Pinned-Dependencies check by `@ramantehlan` in #325

### Other

* feat: add Google Analytics property to the docs site by `@ramantehlan` in #347
* docs: target ~90% unit-test coverage and disable dependabot by `@ramantehlan` in #344
* deps: bump `k8s.io/apimachinery` from 0.34.1 to 0.36.3 in /resolver by `@dependabot` in #340
* ci: bump `docker/setup-buildx-action` from 3.12.0 to 4.2.0 by `@dependabot` in #330
* ci: bump `codecov/codecov-action` from 5.5.5 to 7.0.0 by `@dependabot` in #329
* ci: bump `actions/setup-go` from 4.3.0 to 7.0.0 by `@dependabot` in #328
* ci: bump `actions/stale` from 9.0.0 to 11.0.0 by `@dependabot` in #327
* ci: bump `sigstore/cosign-installer` from 3.9.1 to 4.1.2 by `@dependabot` in #326

### New Contributors

* `@abhishekpradeep124` made their first contribution in #346

`helm lint charts/elasti` and `helm template charts/elasti` both pass.

Once merged, creating the `v0.1.31-rc2` GitHub release (pre-release) triggers the signed-release workflow.
